### PR TITLE
Replace Rails dependency with ActiveRecord

### DIFF
--- a/fc-vault-rails.gemspec
+++ b/fc-vault-rails.gemspec
@@ -17,11 +17,12 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", "LICENSE", "Rakefile", "README.md"]
   s.test_files = Dir["spec/**/*"]
 
-  s.add_dependency "rails", [">= 4.2", "< 5.1"]
+  s.add_dependency "activerecord", [">= 4.2", "< 5.1"]
   s.add_dependency "vault", "~> 0.7"
 
   s.add_development_dependency "appraisal", "~> 2.1"
   s.add_development_dependency "bundler"
+  s.add_development_dependency "rails", [">= 4.2", "< 5.1"]
   s.add_development_dependency "pry"
   s.add_development_dependency "rake",    "~> 10.0"
   s.add_development_dependency "rspec",   "~> 3.2"

--- a/gemfiles/rails_4.2.gemfile.lock
+++ b/gemfiles/rails_4.2.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     fc-vault-rails (0.5.0)
-      rails (>= 4.2, < 5.1)
+      activerecord (>= 4.2, < 5.1)
       vault (~> 0.7)
 
 GEM


### PR DESCRIPTION
VaultRails does really depend on Rails, but rather on ActiveRecord. For now, lets remove the Rails dependency with AR, and deal with namespacing later.

@FundingCircle/gdpr-engineering please 👀 