### PR TITLE
Decrease reliance on rails even more

### DIFF
--- a/lib/vault/rails.rb
+++ b/lib/vault/rails.rb
@@ -24,11 +24,6 @@ module Vault
       float:    Vault::Rails::Serializers::FloatSerializer
     }.freeze
 
-    # The default encoding.
-    #
-    # @return [String]
-    DEFAULT_ENCODING = "utf-8".freeze
-
     # The warning string to print when running in development mode.
     DEV_WARNING = "[vault-rails] Using in-memory cipher - this is not secure " \
       "and should never be used in production-like environments!".freeze
@@ -236,7 +231,7 @@ module Vault
       # newly encoded string.
       # @return [String]
       def force_encoding(str)
-        str.force_encoding(encoding).encode(encoding)
+        str.force_encoding(Vault::Rails.encoding).encode(Vault::Rails.encoding)
       end
 
       private
@@ -261,11 +256,6 @@ module Vault
 
       def log_warning(msg)
         ::ActiveRecord::Base.logger.warn { msg } if ::ActiveRecord::Base.logger
-      end
-
-      def encoding
-        encoding = ::Rails.application.config.encoding if defined?(::Rails)
-        encoding || DEFAULT_ENCODING
       end
     end
   end

--- a/lib/vault/rails.rb
+++ b/lib/vault/rails.rb
@@ -260,9 +260,7 @@ module Vault
       end
 
       def log_warning(msg)
-        if defined?(::Rails) && ::Rails.logger != nil
-          ::Rails.logger.warn { msg }
-        end
+        ::ActiveRecord::Base.logger.warn { msg } if ::ActiveRecord::Base.logger
       end
 
       def encoding

--- a/lib/vault/rails.rb
+++ b/lib/vault/rails.rb
@@ -232,11 +232,10 @@ module Vault
         return Base64.strict_encode64("#{path}/#{key}".ljust(16, "x")).byteslice(0..15)
       end
 
-      # Forces the encoding into the default Rails encoding and returns the
+      # Forces the encoding into the default encoding and returns the
       # newly encoded string.
       # @return [String]
       def force_encoding(str)
-        encoding = ::Rails.application.config.encoding || DEFAULT_ENCODING
         str.force_encoding(encoding).encode(encoding)
       end
 
@@ -264,6 +263,11 @@ module Vault
         if defined?(::Rails) && ::Rails.logger != nil
           ::Rails.logger.warn { msg }
         end
+      end
+
+      def encoding
+        encoding = ::Rails.application.config.encoding if defined?(::Rails)
+        encoding || DEFAULT_ENCODING
       end
     end
   end

--- a/lib/vault/rails/configurable.rb
+++ b/lib/vault/rails/configurable.rb
@@ -3,6 +3,13 @@ module Vault
     module Configurable
       include Vault::Configurable
 
+      # The default encoding, used if Vault::Rails.encoding is not set,
+      # and we're not in a rails app so can't use the default encoding for
+      # the rails app (via Rails.application.config.encoding)
+      #
+      # @return [String]
+      DEFAULT_ENCODING = Encoding::UTF_8
+
       # The name of the Vault::Rails application.
       #
       # @raise [RuntimeError]
@@ -138,6 +145,28 @@ module Vault
       # Sets the convergent encryption context for use with convergent encryption
       def convergent_encryption_context=(context)
         @convergent_encryption_context = context
+      end
+
+      # The encoding to be used when decrypting values.  Defaults to
+      # UTF-8 if not explicitly set.
+      #
+      # @return [String]
+      def encoding
+        @encoding ||= default_encoding
+      end
+
+      # Set the encoding to be used when decrypting values.
+      #
+      # @param [String] new_encoding
+      def encoding=(new_encoding)
+        @encoding = Encoding.find(new_encoding)
+      end
+
+      private
+
+      def default_encoding
+        default_encoding = ::Rails.application.config.encoding if defined?(::Rails)
+        Encoding.find(default_encoding || DEFAULT_ENCODING)
       end
     end
   end

--- a/lib/vault/rails/configurable.rb
+++ b/lib/vault/rails/configurable.rb
@@ -120,13 +120,16 @@ module Vault
         @retry_max_wait = val
       end
 
-      # Gets the convergent encryption context for deriving
-      # an enctyption key when using convergent encryption
-      # Raises an exception when convergent option is set
-      # to true and context is not privided
+      # The convergent encryption context for deriving an
+      # encryption key when using convergent encryption.
+      #
+      # @raise [RuntimeError]
+      #   if the convergent encryption context has not been set
+      #
+      # @return [String]
       def convergent_encryption_context
-        unless @convergent_encryption_context
-          raise StandardError, 'Missinng configuration oprion convergent_encryption_context!'
+        if !defined?(@convergent_encryption_context) || @convergent_encryption_context.nil?
+          raise RuntimeError, "Must set `Vault::Rails.convergent_encryption_context'!"
         end
 
         @convergent_encryption_context

--- a/spec/unit/rails/configurable_spec.rb
+++ b/spec/unit/rails/configurable_spec.rb
@@ -40,4 +40,50 @@ describe Vault::Rails::Configurable do
       end
     end
   end
+
+  describe '.encoding' do
+    context 'when not set explicitly' do
+      context 'but there is a rails encoding setting' do
+        it 'returns that value' do
+          allow(::Rails.application.config).to receive(:encoding).and_return('ISO-8859-1')
+          expect(subject.encoding).to eq(Encoding::ISO_8859_1)
+        end
+
+        it 'raises an exception if that value is not a valid encoding' do
+          allow(::Rails.application.config).to receive(:encoding).and_return('LINEAR_B')
+          expect { subject.encoding }.to raise_exception(ArgumentError, /unknown encoding name - LINEAR_B/)
+        end
+      end
+
+      context 'and there is no rails encoding setting' do
+        it 'returns UTF-8' do
+          allow(::Rails.application.config).to receive(:encoding).and_return(nil)
+          expect(subject.encoding).to eq(Encoding::UTF_8)
+        end
+      end
+
+      context 'and the gem is not in a rails app' do
+        it 'returns UTF-8' do
+          hide_const('Rails')
+          expect(subject.encoding).to eq(Encoding::UTF_8)
+        end
+      end
+    end
+
+    context 'when configured' do
+      it 'returns the configured value' do
+        subject.configure do |vault|
+          vault.encoding = 'ISO-8859-1'
+        end
+
+        expect(subject.encoding).to eq(Encoding::ISO_8859_1)
+      end
+    end
+  end
+
+  context '.encoding=' do
+    it 'raises an exception if the supplied value is not a valid encoding' do
+      expect { subject.encoding = 'LINEAR_B' }.to raise_exception(ArgumentError, /unknown encoding name - LINEAR_B/)
+    end
+  end
 end


### PR DESCRIPTION
We fix two issues when using this version of Vault::Rails in an app that isn't a full rails app and only uses activerecord:

1. Don't rely on `Rails.application.config.encoding` for setting a default encoding on decrypted values
2. Extend the above by allowing an encoding to be set explicitly via `Vault::Rails.configure { |c| c.encoding = '<some encoding name>' }`
3. Use the logger in activerecord rather than trying to use the rails one
