### PR TITLE
Bump to version 0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Vault Rails Changelog
 
+## v0.6.1 (October 16, 2018)
+
+NEW FEATURES
+- Allow specifying encoding for decrypted values via `Vault::Rails.encoding`
+
+BUG FIXES
+- Stop relying on Rails for default encoding of decrypted values
+- Use `ActiveRecord::Base.logger` instead of `Rails.logger`
+- When serialising JSON values pass through nil values as nil, not `{}`
+
 ## v0.6.0 (October 15, 2018)
 
 NOTABLE CHANGES

--- a/gemfiles/rails_4.2.gemfile.lock
+++ b/gemfiles/rails_4.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    fc-vault-rails (0.6.0)
+    fc-vault-rails (0.6.1)
       activerecord (>= 4.2, < 5.1)
       vault (~> 0.7)
 

--- a/lib/vault/rails/version.rb
+++ b/lib/vault/rails/version.rb
@@ -1,5 +1,5 @@
 module Vault
   module Rails
-    VERSION = "0.6.0"
+    VERSION = "0.6.1"
   end
 end


### PR DESCRIPTION
Note that we need to manually tag the repo to release the actual gem.  We'll do that after we've merged this.