### PR TITLE
Add methods for batch decryption and encryption

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,15 @@ vault_attribute :ssn,
 
 - **Note** Convergent encryption significantly weakens the security that encryption provides. Use this with caution!
 
+### Batch encryption and decryption
+There is an option to encrypt or decrypt multiple strings at once.
+All items to be encrypted/decrypted should use the same path, key and client.
+
+``` ruby
+Vault::Rails.batch_decrypt(path, key, <array of ciphertexts>, client)
+Vault::Rails.batch_encrypt(path, key, <array of plaintexts>, client)
+```
+
 
 ### Searching Encrypted Attributes
 Because each column is uniquely encrypted, it is not possible to search for a

--- a/spec/unit/rails_spec.rb
+++ b/spec/unit/rails_spec.rb
@@ -28,7 +28,7 @@ describe Vault::Rails do
         allow(Vault::Rails).to receive(:convergent_encryption_context).and_return('a' * 16)
       end
 
-      it 'sends the correct paramaters to vault client' do
+      it 'sends the correct parameters to vault client' do
         expected_route = 'path/encrypt/key'
         expected_options = {
           plaintext: Base64.strict_encode64('plaintext'),
@@ -50,7 +50,7 @@ describe Vault::Rails do
         allow(Vault::Rails).to receive(:enabled?).and_return(true)
       end
 
-      it 'sends the correct paramaters to vault client' do
+      it 'sends the correct parameters to vault client' do
         expected_route = 'path/encrypt/key'
         expected_options = { plaintext: Base64.strict_encode64('plaintext') }
 
@@ -70,7 +70,7 @@ describe Vault::Rails do
         allow(Vault::Rails).to receive(:convergent_encryption_context).and_return('a' * 16)
       end
 
-      it 'sends the correct paramaters to vault client' do
+      it 'sends the correct parameters to vault client' do
         expected_route = 'path/decrypt/key'
         expected_options = {
           ciphertext: 'ciphertext',
@@ -90,7 +90,7 @@ describe Vault::Rails do
         allow(Vault::Rails).to receive(:enabled?).and_return(true)
       end
 
-      it 'sends the correct paramaters to vault client' do
+      it 'sends the correct parameters to vault client' do
         expected_route = 'path/decrypt/key'
         expected_options = { ciphertext: 'ciphertext' }
 
@@ -100,6 +100,112 @@ describe Vault::Rails do
 
         Vault::Rails.decrypt('path', 'key', 'ciphertext', Vault::Rails.client, false)
       end
+    end
+  end
+
+  describe '.batch_encrypt' do
+    before do
+      allow(Vault::Rails).to receive(:enabled?).and_return(true)
+      allow(Vault::Rails).to receive(:convergent_encryption_context).and_return('a' * 16)
+    end
+
+    it 'sends the correct parameters to vault client' do
+      expected_route = 'path/encrypt/key'
+      expected_options = {
+        batch_input: [
+          {
+            plaintext: Base64.strict_encode64('plaintext1'),
+            context: Base64.strict_encode64(Vault::Rails.convergent_encryption_context),
+          },
+          {
+            plaintext: Base64.strict_encode64('plaintext2'),
+            context: Base64.strict_encode64(Vault::Rails.convergent_encryption_context),
+          },
+        ],
+        convergent_encryption: true,
+        derived: true
+      }
+
+      expect(Vault::Rails.client.logical).to receive(:write)
+        .with(expected_route, expected_options)
+        .and_return(spy('Vault::Secret'))
+
+      Vault::Rails.batch_encrypt('path', 'key', ['plaintext1', 'plaintext2'], Vault::Rails.client)
+    end
+
+    it 'parses the response from vault client correctly' do
+      expected_route = 'path/encrypt/key'
+      expected_options = {
+        batch_input: [
+          {
+            plaintext: Base64.strict_encode64('plaintext1'),
+            context: Base64.strict_encode64(Vault::Rails.convergent_encryption_context),
+          },
+          {
+            plaintext: Base64.strict_encode64('plaintext2'),
+            context: Base64.strict_encode64(Vault::Rails.convergent_encryption_context),
+          },
+        ],
+        convergent_encryption: true,
+        derived: true
+      }
+
+      allow(Vault::Rails.client.logical).to receive(:write)
+        .with(expected_route, expected_options)
+        .and_return(instance_double('Vault::Secret', data: {:batch_results=>[{:ciphertext=>'ciphertext1'}, {:ciphertext=>'ciphertext2'}]}))
+
+      expect(Vault::Rails.batch_encrypt('path', 'key', ['plaintext1', 'plaintext2'], Vault::Rails.client)).to eq(%w(ciphertext1 ciphertext2))
+    end
+  end
+
+  describe '.batch_decrypt' do
+    before do
+      allow(Vault::Rails).to receive(:enabled?).and_return(true)
+      allow(Vault::Rails).to receive(:convergent_encryption_context).and_return('a' * 16)
+    end
+
+    it 'sends the correct parameters to vault client' do
+      expected_route = 'path/decrypt/key'
+      expected_options = {
+        batch_input: [
+          {
+            ciphertext: 'ciphertext1',
+            context: Base64.strict_encode64(Vault::Rails.convergent_encryption_context),
+          },
+          {
+            ciphertext: 'ciphertext2',
+            context: Base64.strict_encode64(Vault::Rails.convergent_encryption_context),
+          },
+        ],
+      }
+
+      expect(Vault::Rails.client.logical).to receive(:write)
+        .with(expected_route, expected_options)
+        .and_return(spy('Vault::Secret'))
+
+      Vault::Rails.batch_decrypt('path', 'key', ['ciphertext1', 'ciphertext2'], Vault::Rails.client)
+    end
+
+    it 'parses the response from vault client correctly' do
+      expected_route = 'path/decrypt/key'
+      expected_options = {
+        batch_input: [
+          {
+            ciphertext: 'ciphertext1',
+            context: Base64.strict_encode64(Vault::Rails.convergent_encryption_context),
+          },
+          {
+            ciphertext: 'ciphertext2',
+            context: Base64.strict_encode64(Vault::Rails.convergent_encryption_context),
+          },
+        ],
+      }
+
+      allow(Vault::Rails.client.logical).to receive(:write)
+        .with(expected_route, expected_options)
+        .and_return(instance_double('Vault::Secret', data: {:batch_results=>[{:plaintext=>'cGxhaW50ZXh0MQ=='}, {:plaintext=>'cGxhaW50ZXh0Mg=='}]}))
+
+      expect(Vault::Rails.batch_decrypt('path', 'key', ['ciphertext1', 'ciphertext2'], Vault::Rails.client)).to eq( %w(plaintext1 plaintext2)) # in that order
     end
   end
 end


### PR DESCRIPTION
Some notes:
- This pull request adds basic support on batch encryption and decryption operations. The current `.encrypt` and `.decrypt` methods don't work with `batch_input` options and responses containing `batch_results`, although batch operations are possible with the [Vault API](https://www.vaultproject.io/api/secret/transit/index.html#batch_input) 🤷‍♀️ 

- According to the API documentation batch operations use the same key for the whole batch

-  I think we need to reorganise this module. Currently it contains too many methods. As a beginning I'd separate the memory methods from the methods, which actually use `vault`. The same thoughts are applicable for the class even without the changes in this pull request. 💭 

- This pull request adds the methods for batch operations but does not integrate them with `ActiveRecord` relations 

/cc @FundingCircle/gdpr-engineering  👀 

