### PR TITLE
Set the encrypted column to nil in the setter

### DIFF
--- a/lib/vault/encrypted_model.rb
+++ b/lib/vault/encrypted_model.rb
@@ -86,6 +86,10 @@ module Vault
         define_method("#{attribute_name}=") do |value|
           # Force the update of the attribute, to be consistent with old behaviour
           attribute_will_change!(attribute_name)
+
+          # Set the encrypted column to nil in the setter so that the getter
+          # does not reset the attribute value to the previous one when it's being to nil.
+          write_attribute(encrypted_column, nil)
           write_attribute(attribute_name, value)
         end
 

--- a/spec/integration/rails_spec.rb
+++ b/spec/integration/rails_spec.rb
@@ -258,6 +258,23 @@ describe Vault::Rails do
       expect(person.credit_card).to be(nil)
     end
 
+    it 'unsets the encrypted column' do
+      person = Person.create!(credit_card: "1234567890111213")
+      person.credit_card = nil
+
+      expect(person.credit_card).to be(nil)
+      expect(person.cc_encrypted).to be(nil)
+    end
+
+    it 'getter does not reset the encrypred attribute' do
+      person = Person.create!(credit_card: "1234567890212223")
+      person.credit_card = nil
+
+      person.credit_card
+
+      expect(person.credit_card).to be(nil)
+    end
+
     it "allows attributes to be blank" do
       person = Person.create!(credit_card: "1234567890111213")
       person.update_attributes!(credit_card: "")


### PR DESCRIPTION
This is needed so that the getter does not reset the attribute value to the previous one when it's being to nil.

@FundingCircle/gdpr-engineering 👀 