### PR TITLE
Change default value of Vault attributes to String

### DIFF
--- a/lib/vault/encrypted_model.rb
+++ b/lib/vault/encrypted_model.rb
@@ -62,7 +62,7 @@ module Vault
           serializer.define_singleton_method(:decode, &options[:decode])
         end
 
-        attribute_type = options.fetch(:type, :value)
+        attribute_type = options.fetch(:type, :string)
 
         if attribute_type.is_a?(Symbol)
           constant_name = attribute_type.to_s.camelize

--- a/spec/dummy/app/models/eager_person.rb
+++ b/spec/dummy/app/models/eager_person.rb
@@ -15,6 +15,7 @@ class EagerPerson < ActiveRecord::Base
     key: "people_credit_cards"
 
   vault_attribute :details,
+    type: :value,
     serialize: :json
 
   vault_attribute :business_card,

--- a/spec/dummy/app/models/lazy_person.rb
+++ b/spec/dummy/app/models/lazy_person.rb
@@ -15,6 +15,7 @@ class LazyPerson < ActiveRecord::Base
     key: "people_credit_cards"
 
   vault_attribute :details,
+    type: :value,
     serialize: :json
 
   vault_attribute :business_card,

--- a/spec/dummy/app/models/person.rb
+++ b/spec/dummy/app/models/person.rb
@@ -17,6 +17,7 @@ class Person < ActiveRecord::Base
     key: "people_credit_cards"
 
   vault_attribute :details,
+    type: :value,
     serialize: :json
 
   vault_attribute :business_card,


### PR DESCRIPTION
Since Vault assumes that all attributes are `String`s, unless explicitly
defined otherwise, it makes sense to have this as a default. This will make
it easier (shorter) to define attributes like house and phone numbers for
example, where they can include only numbers and be mistaked for Integers
by ActiveRecord.

@FundingCircle/gdpr-engineering 👀 