### PR TITLE
Add attribute proxy for transition between plaintext and ciphertext fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,15 @@ Person.where(ssn: "123-45-6789")
 This is because the database is unaware of the plain-text data (which is part of
 the security model).
 
+### Vault Attribute Proxy
+This method is useful if you have a plaintext attribute that you want to replace with a vault attribute.
+During a transition period both attributes can be seamlessly read/changed at the same time.
+Then by using the boolean option `encrypted_attribute_only`, you will be able to test if the ciphertext field works as expected before getting rid of the plaintext attribute.
+In order to use this method for an attribute you need to add the following row in your model for given plaintext and ciphertext attributes:
+```ruby
+vault_attribute_proxy :attribute, :attribute_ciphertext, encrypted_attribute_only: true
+```
+
 
 Development
 -----------

--- a/gemfiles/rails_4.2.gemfile.lock
+++ b/gemfiles/rails_4.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    fc-vault-rails (0.6.1)
+    fc-vault-rails (0.6.3)
       activerecord (>= 4.2, < 5.1)
       vault (~> 0.7)
 

--- a/lib/vault/attribute_proxy.rb
+++ b/lib/vault/attribute_proxy.rb
@@ -36,7 +36,23 @@ module Vault
         define_method("#{non_encrypted_attribute}=") do |value|
           super(value) unless options[:encrypted_attribute_only]
 
-          send("#{encrypted_attribute}=", value)
+          # Manual casting is necessary. Because if encrypted_attribute_only, we may not call super
+          # and cannot rely on ActiveRecord to do the casting for us.
+          type_constant_name = options.fetch(:type, :string).to_s.camelize
+
+          type = ActiveRecord::Type.const_get(type_constant_name).new
+
+          cast_value = if type.respond_to? :type_cast_from_user
+                         # ActiveRecord 4.2
+                         type.type_cast_from_user(value)
+                       elsif type.respond_to? :serialize
+                         # ActiveRecord 5.0
+                         type.serialize(value)
+                       else
+                         value
+                       end
+
+          send("#{encrypted_attribute}=", cast_value)
         end
       end
     end

--- a/lib/vault/attribute_proxy.rb
+++ b/lib/vault/attribute_proxy.rb
@@ -1,0 +1,44 @@
+
+# A simple proxy that aids the transition from
+# non-encrypted atributes to encrypted ones.
+module Vault
+  module AttributeProxy
+    extend ActiveSupport::Concern
+
+    module ClassMethods
+      # Define proxy getter and setter methods
+      #
+      # Override the getter and setter for a particular non-encrypted attribute
+      # so that they also call the getter/setter of the encrypted one.
+      # This ensures that all the code that uses the attribute in question
+      # also updates/retrieves the encrypted value whenever it is available.
+      #
+      # This method is useful if you have a plaintext attribute that you want to replace with a vault attribute.
+      # During a transition period both attributes can be seamlessly read/changed at the same time.
+      #
+      # @param [String | Symbol] non_encrypted_attribute
+      #   The name of original attribute (non-encrypted).
+      # @param [String | Symbol] encrypted_attribute
+      #   The name of the encrypted attribute.
+      #   This makes sure that the encrypted attribute behaves like a real AR attribute.
+      # @param [Boolean] (false) encrypted_attribute_only
+      #   Whether to read and write to both encrypted and non-encrypted attributes.
+      #   Useful for when we stop using the non-encrypted one.
+      def vault_attribute_proxy(non_encrypted_attribute, encrypted_attribute, options={})
+        # Only return the encrypted attribute if it's available and encrypted_attribute_only is true.
+        define_method(non_encrypted_attribute) do
+          return send(encrypted_attribute) if options[:encrypted_attribute_only]
+
+          send(encrypted_attribute) || super()
+        end
+
+        # Update only the encrypted attribute if encrypted_attribute_only is true and both attributes otherwise.
+        define_method("#{non_encrypted_attribute}=") do |value|
+          super(value) unless options[:encrypted_attribute_only]
+
+          send("#{encrypted_attribute}=", value)
+        end
+      end
+    end
+  end
+end

--- a/lib/vault/rails.rb
+++ b/lib/vault/rails.rb
@@ -4,6 +4,7 @@ require 'base64'
 require 'json'
 
 require_relative 'encrypted_model'
+require_relative 'attribute_proxy'
 require_relative 'rails/configurable'
 require_relative 'rails/errors'
 require_relative 'rails/serializers/json_serializer'

--- a/lib/vault/rails/version.rb
+++ b/lib/vault/rails/version.rb
@@ -1,5 +1,5 @@
 module Vault
   module Rails
-    VERSION = "0.6.1"
+    VERSION = "0.6.2"
   end
 end

--- a/lib/vault/rails/version.rb
+++ b/lib/vault/rails/version.rb
@@ -1,5 +1,5 @@
 module Vault
   module Rails
-    VERSION = "0.6.2"
+    VERSION = "0.6.3"
   end
 end

--- a/spec/dummy/app/models/lazy_person.rb
+++ b/spec/dummy/app/models/lazy_person.rb
@@ -10,6 +10,9 @@ class LazyPerson < ActiveRecord::Base
 
   vault_attribute :ssn
 
+  vault_attribute :date_of_birth_plaintext
+  vault_attribute_proxy :date_of_birth, :date_of_birth_plaintext, type: :date
+
   vault_attribute :credit_card,
     encrypted_column: :cc_encrypted,
     path: "credit-secrets",

--- a/spec/dummy/app/models/lazy_person.rb
+++ b/spec/dummy/app/models/lazy_person.rb
@@ -2,6 +2,7 @@ require "binary_serializer"
 
 class LazyPerson < ActiveRecord::Base
   include Vault::EncryptedModel
+  include Vault::AttributeProxy
 
   self.table_name = "people"
 

--- a/spec/dummy/app/models/person.rb
+++ b/spec/dummy/app/models/person.rb
@@ -4,6 +4,9 @@ class Person < ActiveRecord::Base
   include Vault::EncryptedModel
   include Vault::AttributeProxy
 
+  vault_attribute :date_of_birth_plaintext
+  vault_attribute_proxy :date_of_birth, :date_of_birth_plaintext, type: :date
+
   vault_attribute :county_plaintext, encrypted_column: :county_encrypted
   vault_attribute_proxy :county, :county_plaintext
 

--- a/spec/dummy/app/models/person.rb
+++ b/spec/dummy/app/models/person.rb
@@ -2,6 +2,13 @@ require "binary_serializer"
 
 class Person < ActiveRecord::Base
   include Vault::EncryptedModel
+  include Vault::AttributeProxy
+
+  vault_attribute :county_plaintext, encrypted_column: :county_encrypted
+  vault_attribute_proxy :county, :county_plaintext
+
+  vault_attribute :state_plaintext, encrypted_column: :state_encrypted
+  vault_attribute_proxy :state, :state_plaintext, encrypted_attribute_only: true
 
   vault_attribute :ssn
 

--- a/spec/dummy/db/migrate/20181017154000_add_county_and_state_to_people.rb
+++ b/spec/dummy/db/migrate/20181017154000_add_county_and_state_to_people.rb
@@ -1,0 +1,10 @@
+class AddCountyAndStateToPeople < ActiveRecord::Migration[5.0]
+  def change
+    add_column :people, :county, :string
+    add_column :people, :county_encrypted, :string
+
+    add_column :people, :state, :string
+    add_column :people, :state_encrypted, :string
+  end
+end
+

--- a/spec/dummy/db/migrate/20181030234312_add_date_of_birth_to_people.rb
+++ b/spec/dummy/db/migrate/20181030234312_add_date_of_birth_to_people.rb
@@ -1,0 +1,6 @@
+class AddDateOfBirthToPeople < ActiveRecord::Migration[5.0]
+  def change
+    add_column :people, :date_of_birth, :string
+    add_column :people, :date_of_birth_encrypted, :string
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180816090008) do
+ActiveRecord::Schema.define(version: 20181017154000) do
 
   create_table "people", force: :cascade do |t|
     t.string   "name"
@@ -23,6 +23,10 @@ ActiveRecord::Schema.define(version: 20180816090008) do
     t.datetime "created_at",               null: false
     t.datetime "updated_at",               null: false
     t.string   "email_encrypted"
+    t.string   "county"
+    t.string   "county_encrypted"
+    t.string   "state"
+    t.string   "state_encrypted"
   end
 
 end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181017154000) do
+ActiveRecord::Schema.define(version: 20181030234312) do
 
   create_table "people", force: :cascade do |t|
     t.string   "name"
@@ -27,6 +27,8 @@ ActiveRecord::Schema.define(version: 20181017154000) do
     t.string   "county_encrypted"
     t.string   "state"
     t.string   "state_encrypted"
+    t.string   "date_of_birth"
+    t.string   "date_of_birth_encrypted"
   end
 
 end

--- a/spec/unit/attribute_proxy_spec.rb
+++ b/spec/unit/attribute_proxy_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+
+RSpec.describe 'vault_attribute_proxy' do
+  let(:person) { Person.new }
+
+  context 'with encrypted_attribute_only false' do
+    it 'fills both attributes' do
+      county = 'Orange'
+      person.county = county
+
+      expect(person.county).to eq county
+      expect(person.county_plaintext).to eq county
+    end
+
+    it 'reads first from the encrypted attribute' do
+      person.county_plaintext = 'Yellow'
+      expect(person.county).to eq('Yellow')
+    end
+
+    it 'reads from the plain text attribute when encrypted attribute is not available' do
+      person.county = 'Blue'
+      person.county_plaintext = nil
+
+      expect(person.county).to eq('Blue')
+    end
+  end
+
+  context 'with encrypted_attribute_only true' do
+    it 'fills only the encrypted attribute' do
+      person.state = 'California'
+
+      expect(person.state_plaintext).to eq 'California'
+      expect(person.read_attribute(:state)).to be_nil
+    end
+
+    it 'reads first from the encrypted attribute' do
+      person.state_plaintext = 'New York'
+      expect(person.state).to eq 'New York'
+    end
+
+    it 'returns nil when encrypted attribute is not available' do
+      person.state = 'Florida'
+      person.state_plaintext = nil
+
+      expect(person.state).to be_nil
+    end
+  end
+end

--- a/spec/unit/attribute_proxy_spec.rb
+++ b/spec/unit/attribute_proxy_spec.rb
@@ -3,6 +3,18 @@ require 'spec_helper'
 RSpec.describe 'vault_attribute_proxy' do
   let(:person) { Person.new }
 
+  context 'when called with type other than string' do
+    it 'casts the value to the correct type' do
+      date_string = '2000-10-10'
+      date = Date.parse(date_string)
+
+      person.date_of_birth = date_string
+
+      expect(person.date_of_birth).to eq date
+      expect(person.date_of_birth_plaintext).to eq date
+    end
+  end
+
   context 'with encrypted_attribute_only false' do
     it 'fills both attributes' do
       county = 'Orange'


### PR DESCRIPTION
`vault_attribute_proxy` defines proxy getter and setter methods

It overrides the getter and setter for a particular non-encrypted attribute so that they also call the getter/setter of the encrypted one.
This ensures that all the code that uses the attribute in question also updates/retrieves the encrypted value whenever it is available.

This method is useful if you have a plaintext attribute that you want to replace with a vault attribute.
During a transition period both attributes can be seamlessly read/changed at the same time.
Then by using the boolean option `encrypted_attribute_only`, you will be able to test if the ciphertext field works as expected before getting rid of the plaintext attribute.

