### PR TITLE
Fix CircleCI for 0.6 releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,83 +1,127 @@
 version: 2
+
+defaults: &defaults
+  docker:
+    - image: quay.io/fundingcircle/centos-ruby:ci-rvm
+      auth:
+        username: $DOCKER_USERNAME
+        password: $DOCKER_PASSWORD
+      environment:
+        RACK_ENV: test
+        VAULT_VERSION: 0.10.4
+
 jobs:
   tests:
-    docker:
-      - image: ruby:2.4.4-alpine
-        environment:
-          RACK_ENV: test
-          VAULT_VERSION: 0.10.0
+    <<: *defaults
+
     steps:
       - checkout
-      - run: apk add --no-cache build-base sqlite-dev tzdata
+      - run: yum -y install wget unzip sqlite
+      - run: yum clean all
+
       - run:
           name: Install Vault
           command: |
             wget -O vault.zip -q https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_linux_amd64.zip
             unzip vault.zip
             mv vault /usr/local/bin/
+
       - restore_cache:
           keys:
-            - vault-rails-{{checksum "fc-vault-rails.gemspec" }}
-      - run: bundle check --path=vendor/bundle || bundle install --path=vendor/bundle
+            - vault-rails-{{checksum "fc-vault-rails.gemspec" }}-{{checksum ".travis.yml" }}
+
+      - run:
+          shell: /bin/bash -l
+          command: |
+            rvm use --default 2.5.1
+            bundle check --path=/usr/local/rvm/gems || bundle install --path=/usr/local/rvm/gems
+
+      - run:
+          shell: /bin/bash -l
+          command: |
+            bundle exec rake app:db:create
+            bundle exec rake app:db:schema:load
+            bundle exec rake app:db:test:prepare
+            bundle exec wwtd
+
       - save_cache:
-          key: vault-rails-{{checksum "fc-vault-rails.gemspec" }}
+          key: vault-rails-{{checksum "fc-vault-rails.gemspec" }}-{{checksum ".travis.yml" }}
           paths:
-            - vendor/bundle
-      - run: bundle exec rake app:db:create
-      - run: bundle exec rake app:db:schema:load
-      - run: bundle exec rake app:db:test:prepare
-      - run: bundle exec rspec
+            - /usr/local/rvm/gems
 
   publish-pre-release:
-    docker:
-      - image: ruby:2.4.4-alpine
+    <<: *defaults
+
     steps:
       - checkout
-      - run:
-          name: Install cURL
-          command: apk add --no-cache curl
+      - run: yum -y install curl
+      - run: yum clean all
+
       - run:
           name: Login to JFrog
           command: |
             mkdir -p ~/.gem
             curl --user "$ARTIFACTORY_USER:$ARTIFACTORY_PASSWORD" https://fundingcircle.jfrog.io/fundingcircle/api/gems/rubygems/api/v1/api_key.yaml > ~/.gem/credentials
             chmod 600 ~/.gem/credentials
+
+      - run:
+          shell: /bin/bash -l
+          command: |
+            rvm use --default 2.5.1
+
       - run:
           name: Install Gem Versioner
+          shell: /bin/bash -l
           command: gem install gem-versioner --version '~> 1.0' --no-document
+
       - run:
           name: Build gem
+          shell: /bin/bash -l
           command: |
             PRE_RELEASE="$CIRCLE_BRANCH" gem build fc-vault-rails.gemspec
+
       - run:
           name: Publish gem
+          shell: /bin/bash -l
           command: |
             package=$(ls -t1 fc-vault-rails-*.gem | head -1)
             gem push "$package" --host https://fundingcircle.jfrog.io/fundingcircle/api/gems/rubygems-pre-releases
 
   publish-release:
-    docker:
-      - image: ruby:2.4.4-alpine
+    <<: *defaults
+
     steps:
+
       - checkout
-      - run:
-          name: Install cURL
-          command: apk add --no-cache curl git
+      - run: yum -y install curl
+      - run: yum clean all
+
       - run:
           name: Login to JFrog
           command: |
             mkdir -p ~/.gem
             curl --user "$ARTIFACTORY_USER:$ARTIFACTORY_PASSWORD" https://fundingcircle.jfrog.io/fundingcircle/api/gems/rubygems/api/v1/api_key.yaml > ~/.gem/credentials
             chmod 600 ~/.gem/credentials
+
+      - run:
+        shell: /bin/bash -l
+        command: |
+          rvm use --default 2.5.1
+
       - run:
           name: Install Gem Versioner
+          shell: /bin/bash -l
           command: gem install gem-versioner --version '~> 1.0' --no-document
+
       - run:
           name: Build gem
+          shell: /bin/bash -l
           command: |
             gem build fc-vault-rails.gemspec
+
       - run:
           name: Publish gem
+          shell: /bin/bash -l
           command: |
             package=$(ls -t1 fc-vault-rails-*.gem | head -1)
             gem push "$package" --host https://fundingcircle.jfrog.io/fundingcircle/api/gems/rubygems-local
@@ -88,9 +132,11 @@ workflows:
   test-and-release:
     jobs:
       - tests:
+          context: org-global
           filters:
             tags:
               only: /.*/
+
       - publish-pre-release:
           context: org-global
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,8 +66,7 @@ jobs:
 
       - run:
           shell: /bin/bash -l
-          command: |
-            rvm use --default 2.5.1
+          command: rvm use --default 2.5.1
 
       - run:
           name: Install Gem Versioner
@@ -91,7 +90,6 @@ jobs:
     <<: *defaults
 
     steps:
-
       - checkout
       - run: yum -y install curl
       - run: yum clean all
@@ -104,9 +102,8 @@ jobs:
             chmod 600 ~/.gem/credentials
 
       - run:
-        shell: /bin/bash -l
-        command: |
-          rvm use --default 2.5.1
+          shell: /bin/bash -l
+          command: rvm use --default 2.5.1
 
       - run:
           name: Install Gem Versioner

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,6 @@ cache: bundler
 dist: trusty
 sudo: false
 
-env:
-  - VAULT_VERSION=0.10.4
-  - VAULT_VERSION=0.9.6
-  - VAULT_VERSION=0.8.3
-  - VAULT_VERSION=0.7.3
-
 gemfile:
   - Gemfile
   - gemfiles/rails_4.2.gemfile
@@ -25,14 +19,17 @@ branches:
     - master
 
 rvm:
-  - 2.2.8
-  - 2.3.5
-  - 2.4.2
+  - 2.2.10
+  - 2.3.7
+  - 2.4.4
+  - 2.5.1
 
 matrix:
   exclude:
     # Json 1.8.3 cannot build json gem dependency any longer with Ruby 2.4
-    - rvm: 2.4.2
+    - rvm: 2.4.4
+      gemfile: gemfiles/rails_4.2.gemfile
+    - rvm: 2.5.1
       gemfile: gemfiles/rails_4.2.gemfile
 
 before_script:

--- a/fc-vault-rails.gemspec
+++ b/fc-vault-rails.gemspec
@@ -27,4 +27,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rake",    "~> 10.0"
   s.add_development_dependency "rspec",   "~> 3.2"
   s.add_development_dependency "sqlite3"
+  s.add_development_dependency "wwtd"
 end

--- a/gemfiles/rails_4.2.gemfile.lock
+++ b/gemfiles/rails_4.2.gemfile.lock
@@ -132,6 +132,7 @@ GEM
       thread_safe (~> 0.1)
     vault (0.12.0)
       aws-sigv4
+    wwtd (1.3.0)
 
 PLATFORMS
   ruby
@@ -145,6 +146,7 @@ DEPENDENCIES
   rake (~> 10.0)
   rspec (~> 3.2)
   sqlite3
+  wwtd
 
 BUNDLED WITH
    1.16.2


### PR DESCRIPTION
There is currently a difference between the `CircleCI` config on `master` and on `0.6-stable`.
That might be the reason why I can't currently release `v0.6.4` 😕 

/cc @FundingCircle/gdpr-engineering 👀 