### PR TITLE
Prepare for 0.7.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 
 NEW FEATURES
+- Support for batch encryption/decryption via `Vault::Rails.batch_encrypt`
+  and `Vault::Rails.batch_decrypt` methods.
 - Introduce deprecation warnings for the breaking changes between 0.6 and
   0.7.  This includes adding back `Vault::AttributeProxy` as an empty
   module that generates a deprecation warning.
@@ -10,6 +12,7 @@ NEW FEATURES
 BUG FIXES
 - Actually persist encrypted attributes when using
   `vault_persist_before_save!` in rails 5.2
+- Support lazy loading of `nil` values.
 
 ## v0.7.0 (October 24, 2018)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+NEW FEATURES
+- Introduce deprecation warnings for the breaking changes between 0.6 and
+  0.7.  This includes adding back `Vault::AttributeProxy` as an empty
+  module that generates a deprecation warning.
+
 BUG FIXES
 - Actually persist encrypted attributes when using
   `vault_persist_before_save!` in rails 5.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Vault Rails Changelog
 
-## Unreleased
+## v0.7.1 (November 21, 2018)
 
 NEW FEATURES
 - Support for batch encryption/decryption via `Vault::Rails.batch_encrypt`

--- a/README.md
+++ b/README.md
@@ -293,6 +293,18 @@ In order to use this method for an attribute you need to add the following row i
 vault_attribute_proxy :attribute, :attribute_ciphertext, encrypted_attribute_only: true
 ```
 
+Upgrading to 0.7 from 0.6
+-------------------------
+
+Version 0.6 targets rails 4.x and 0.7 targets rails 5.x.  There are breaking changes between the two versions too, so upgrading isn't as smooth as it could be.
+
+1. You no longer need to `include Vault::AttributeProxy` to get `vault_attribute_proxy` as it is part of `Vault::EncryptedModel` now. In 0.7.0 the `Vault::AttributeProxy` module isn't part of the gem, but from 0.7.1+ it exists just to emit a deprecation warning reminding you to stop including it.
+
+    **If you do nothing** your app will still work properly in 0.7.1+, but you'll get annoying messages.
+
+2. The position of the `type` parameter has changed from `vault_attribute_proxy` in 0.6 to `vault_attribute` in 0.7.  In 0.7 if you have a `type` option on `vault_attribute_proxy` it will emit a deprecation warning reminding you to move the definition onto `vault_attribute`.
+
+    **If you do nothing** your app will likely break because `fc-vault-rails` will assume your `vault_attribute` is just a string and if you had `type` on `vault_attribute_proxy` it's likely not.
 
 Development
 -----------

--- a/gemfiles/rails_4.2.gemfile.lock
+++ b/gemfiles/rails_4.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    fc-vault-rails (0.7.0)
+    fc-vault-rails (0.7.1)
       activerecord (>= 4.2.8, < 6.0)
       vault (~> 0.7)
 
@@ -148,4 +148,4 @@ DEPENDENCIES
   wwtd
 
 BUNDLED WITH
-   1.16.2
+   1.16.6

--- a/gemfiles/rails_5.0.gemfile.lock
+++ b/gemfiles/rails_5.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    fc-vault-rails (0.7.0)
+    fc-vault-rails (0.7.1)
       activerecord (>= 4.2.8, < 6.0)
       vault (~> 0.7)
 

--- a/gemfiles/rails_5.1.gemfile.lock
+++ b/gemfiles/rails_5.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    fc-vault-rails (0.7.0)
+    fc-vault-rails (0.7.1)
       activerecord (>= 4.2.8, < 6.0)
       vault (~> 0.7)
 

--- a/gemfiles/rails_5.2.gemfile.lock
+++ b/gemfiles/rails_5.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    fc-vault-rails (0.7.0)
+    fc-vault-rails (0.7.1)
       activerecord (>= 4.2.8, < 6.0)
       vault (~> 0.7)
 

--- a/lib/vault/attribute_proxy.rb
+++ b/lib/vault/attribute_proxy.rb
@@ -1,0 +1,12 @@
+require "active_support/concern"
+require "active_support/deprecation"
+
+module Vault
+  module AttributeProxy
+    extend ActiveSupport::Concern
+
+    included do
+      ActiveSupport::Deprecation.warn('Vault::AttributeProxy is no longer required, `vault_attribute_proxy` comes via `Vault::EncryptedModel` so you can remove `include Vault::AttributeProxy` from your model.')
+    end
+  end
+end

--- a/lib/vault/encrypted_model.rb
+++ b/lib/vault/encrypted_model.rb
@@ -138,6 +138,9 @@ module Vault
       #   Whether to read and write to both encrypted and non-encrypted attributes.
       #   Useful for when we stop using the non-encrypted one.
       def vault_attribute_proxy(non_encrypted_attribute, encrypted_attribute, options={})
+        if options[:type].present?
+          ActiveSupport::Deprecation.warn('The `type` option on `vault_attribute_proxy` is now ignored.  To specify type information you should move the `type` option onto the `vault_attribute` definition.')
+        end
         # Only return the encrypted attribute if it's available and encrypted_attribute_only is true.
         define_method(non_encrypted_attribute) do
           return send(encrypted_attribute) if options[:encrypted_attribute_only]

--- a/lib/vault/rails.rb
+++ b/lib/vault/rails.rb
@@ -4,6 +4,7 @@ require 'base64'
 require 'json'
 
 require_relative 'encrypted_model'
+require_relative 'attribute_proxy'
 require_relative 'rails/configurable'
 require_relative 'rails/errors'
 require_relative 'rails/serializers/json_serializer'

--- a/lib/vault/rails/version.rb
+++ b/lib/vault/rails/version.rb
@@ -1,5 +1,5 @@
 module Vault
   module Rails
-    VERSION = "0.7.0"
+    VERSION = "0.7.1"
   end
 end


### PR DESCRIPTION
Go commit-by-commit for the full details, but the tl;dr is:

1. Add deprecation warnings for 0.6 -> 0.7 changes
2. Documentation for 0.6 -> 0.7 upgrade
3. Update changelog
4. Bump version to 0.7.1