### PR TITLE
New `ipaddr`, `date` and `datetime` types for 0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 NEW FEATURES
 - New serializers for `time` and `datetime`
+- New serializer for `ipaddr`.
 
 ## v0.6.5 (November 28, 2018)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Vault Rails Changelog
 
+## Unreleased
+
+NEW FEATURES
+- New serializers for `time` and `datetime`
+
 ## v0.6.5 (November 28, 2018)
 
 IMPROVEMENTS

--- a/lib/vault/rails.rb
+++ b/lib/vault/rails.rb
@@ -12,6 +12,8 @@ require_relative 'rails/serializers/json_serializer'
 require_relative 'rails/serializers/date_serializer'
 require_relative 'rails/serializers/integer_serializer'
 require_relative 'rails/serializers/float_serializer'
+require_relative 'rails/serializers/time_serializer'
+require_relative 'rails/serializers/date_time_serializer'
 require_relative 'rails/version'
 
 module Vault
@@ -23,7 +25,9 @@ module Vault
       json:     Vault::Rails::Serializers::JSONSerializer,
       date:     Vault::Rails::Serializers::DateSerializer,
       integer:  Vault::Rails::Serializers::IntegerSerializer,
-      float:    Vault::Rails::Serializers::FloatSerializer
+      float:    Vault::Rails::Serializers::FloatSerializer,
+      time:     Vault::Rails::Serializers::TimeSerializer,
+      datetime: Vault::Rails::Serializers::DateTimeSerializer
     }.freeze
 
     # The warning string to print when running in development mode.

--- a/lib/vault/rails.rb
+++ b/lib/vault/rails.rb
@@ -14,6 +14,7 @@ require_relative 'rails/serializers/integer_serializer'
 require_relative 'rails/serializers/float_serializer'
 require_relative 'rails/serializers/time_serializer'
 require_relative 'rails/serializers/date_time_serializer'
+require_relative 'rails/serializers/ipaddr_serializer'
 require_relative 'rails/version'
 
 module Vault
@@ -27,7 +28,8 @@ module Vault
       integer:  Vault::Rails::Serializers::IntegerSerializer,
       float:    Vault::Rails::Serializers::FloatSerializer,
       time:     Vault::Rails::Serializers::TimeSerializer,
-      datetime: Vault::Rails::Serializers::DateTimeSerializer
+      datetime: Vault::Rails::Serializers::DateTimeSerializer,
+      ipaddr:   Vault::Rails::Serializers::IPAddrSerializer,
     }.freeze
 
     # The warning string to print when running in development mode.

--- a/lib/vault/rails/serializers/date_time_serializer.rb
+++ b/lib/vault/rails/serializers/date_time_serializer.rb
@@ -1,0 +1,17 @@
+module Vault
+  module Rails
+    module Serializers
+      # Converts datetime objects to and from ISO 8601 format with 3
+      # fractional seconds
+      module DateTimeSerializer
+        include TimeSerializer
+        module_function :encode, :decode
+
+        def decode(raw)
+          time = super
+          time.present? ? time.to_datetime : time
+        end
+      end
+    end
+  end
+end

--- a/lib/vault/rails/serializers/ipaddr_serializer.rb
+++ b/lib/vault/rails/serializers/ipaddr_serializer.rb
@@ -1,0 +1,21 @@
+module Vault
+  module Rails
+    module Serializers
+      # Converts IPAddr objects to and from strings
+      module IPAddrSerializer
+        module_function
+
+        def encode(ip_addr)
+          return nil if ip_addr.blank?
+
+          "#{ip_addr}/#{ip_addr.instance_variable_get(:@mask_addr).to_s(2).count('1')}"
+        end
+
+        def decode(string)
+          return nil if string.blank?
+          IPAddr.new(string)
+        end
+      end
+    end
+  end
+end

--- a/lib/vault/rails/serializers/time_serializer.rb
+++ b/lib/vault/rails/serializers/time_serializer.rb
@@ -1,0 +1,23 @@
+module Vault
+  module Rails
+    module Serializers
+      # Converts time objects to and from ISO 8601 format with 3
+      # fractional seconds
+      module TimeSerializer
+        module_function
+
+        def encode(raw)
+          return nil if raw.blank?
+
+          raw = Time.parse(raw) if raw.is_a? String
+          raw.iso8601(3)
+        end
+
+        def decode(raw)
+          return nil if raw.blank?
+          Time.iso8601(raw)
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/rails/serializers/date_serializer_spec.rb
+++ b/spec/unit/rails/serializers/date_serializer_spec.rb
@@ -2,11 +2,11 @@ require 'spec_helper'
 
 describe Vault::Rails::Serializers::DateSerializer do
   it 'encodes values to strings' do
-    expect(subject.encode(Date.new(1999, 1, 1))). to eq '1999-01-01'
+    expect(subject.encode(Date.new(1999, 1, 1))).to eq '1999-01-01'
   end
 
   it 'decodes values from strings' do
-    expect(subject.decode('1999-12-31')). to eq Date.new(1999, 12, 31)
+    expect(subject.decode('1999-12-31')).to eq Date.new(1999, 12, 31)
   end
 end
 

--- a/spec/unit/rails/serializers/date_serializer_spec.rb
+++ b/spec/unit/rails/serializers/date_serializer_spec.rb
@@ -9,4 +9,3 @@ describe Vault::Rails::Serializers::DateSerializer do
     expect(subject.decode('1999-12-31')).to eq Date.new(1999, 12, 31)
   end
 end
-

--- a/spec/unit/rails/serializers/date_time_serializer_spec.rb
+++ b/spec/unit/rails/serializers/date_time_serializer_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe Vault::Rails::Serializers::DateTimeSerializer do
+  it 'encodes values to strings' do
+    expect(subject.encode(DateTime.new(1999, 1, 1, 10, 11, 12.134, '0'))).to eq '1999-01-01T10:11:12.134+00:00'
+  end
+
+  it 'decodes values from strings' do
+    expect(subject.decode('1999-12-31T20:21:22.234+00:00')).to eq DateTime.new(1999, 12, 31, 20, 21, 22.234, '0')
+  end
+end

--- a/spec/unit/rails/serializers/float_serializer_spec.rb
+++ b/spec/unit/rails/serializers/float_serializer_spec.rb
@@ -2,14 +2,14 @@ require 'spec_helper'
 
 describe Vault::Rails::Serializers::FloatSerializer do
   it 'encodes values to strings' do
-    expect(subject.encode(1.0)). to eq '1.0'
-    expect(subject.encode(42.00001)). to eq '42.00001'
-    expect(subject.encode(435345.40035)). to eq '435345.40035'
+    expect(subject.encode(1.0)).to eq '1.0'
+    expect(subject.encode(42.00001)).to eq '42.00001'
+    expect(subject.encode(435345.40035)).to eq '435345.40035'
   end
 
   it 'decodes values from strings' do
-    expect(subject.decode('1.0')). to eq 1.0
-    expect(subject.decode('42')). to eq 42.0
-    expect(subject.decode('435345.40035')). to eq 435345.40035
+    expect(subject.decode('1.0')).to eq 1.0
+    expect(subject.decode('42')).to eq 42.0
+    expect(subject.decode('435345.40035')).to eq 435345.40035
   end
 end

--- a/spec/unit/rails/serializers/integer_serializer_spec.rb
+++ b/spec/unit/rails/serializers/integer_serializer_spec.rb
@@ -2,14 +2,14 @@ require 'spec_helper'
 
 describe Vault::Rails::Serializers::IntegerSerializer do
   it 'encodes values to strings' do
-    expect(subject.encode(1)). to eq '1'
-    expect(subject.encode(42)). to eq '42'
-    expect(subject.encode(23425)). to eq '23425'
+    expect(subject.encode(1)).to eq '1'
+    expect(subject.encode(42)).to eq '42'
+    expect(subject.encode(23425)).to eq '23425'
   end
 
   it 'decodes values from strings' do
-    expect(subject.decode('1')). to eq 1
-    expect(subject.decode('42')). to eq 42
-    expect(subject.decode('23425')). to eq 23425
+    expect(subject.decode('1')).to eq 1
+    expect(subject.decode('42')).to eq 42
+    expect(subject.decode('23425')).to eq 23425
   end
 end

--- a/spec/unit/rails/serializers/ipaddr_serializer_spec.rb
+++ b/spec/unit/rails/serializers/ipaddr_serializer_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+describe Vault::Rails::Serializers::IPAddrSerializer do
+  it 'encodes values to strings for IP4 addresses' do
+    expect(subject.encode(IPAddr.new('192.168.1.255/32'))).to eq '192.168.1.255/32'
+  end
+
+  it 'decodes values from strings for IP4 addresses' do
+    expect(subject.decode('192.168.1.1/1')).to eq IPAddr.new('192.168.1.1/1')
+  end
+
+  it 'encodes values to strings for IP6 addresses' do
+    expect(subject.encode(IPAddr.new('fd12:3456:789a:1::ffff/128'))).to eq 'fd12:3456:789a:1::ffff/128'
+  end
+
+  it 'decodes values from strings for IP6 addresses' do
+    expect(subject.decode('fd12:3456:789a:1::1/1')).to eq IPAddr.new('fd12:3456:789a:1::1/1')
+  end
+end

--- a/spec/unit/rails/serializers/json_serializer_spec.rb
+++ b/spec/unit/rails/serializers/json_serializer_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe Vault::Rails::Serializers::JSONSerializer do
+  it 'encodes values to strings' do
+    expect(subject.encode({"foo" => "bar", "baz" => 1})).to eq '{"foo":"bar","baz":1}'
+  end
+
+  it 'decodes values from strings' do
+    expect(subject.decode('{"foo":"bar","baz":1}')).to eq({"foo" => "bar", "baz" => 1})
+  end
+end

--- a/spec/unit/rails/serializers/time_serializer_spec.rb
+++ b/spec/unit/rails/serializers/time_serializer_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe Vault::Rails::Serializers::TimeSerializer do
+  it 'encodes values to strings' do
+    expect(subject.encode(Time.utc(1999, 1, 1, 10, 11, 12, 134000))).to eq '1999-01-01T10:11:12.134Z'
+  end
+
+  it 'decodes values from strings' do
+    expect(subject.decode('1999-12-31T20:21:22.234Z')).to eq Time.utc(1999, 12, 31, 20, 21, 22, 234000)
+  end
+end


### PR DESCRIPTION
This is the 0.6 version of #44.  We only add the new serializers for `date`, `datetime`, and `ipaddr`.  We don't add the automatic lookup of the serializer based on the type because while serialization options are specified on `vault_attribute`, the `type` option is on the `vault_attribute_proxy` and it feels wrong to have the definition of `vault_attribute_proxy` make changes to the definition of `vault_attribute`.