### PR TITLE
Handle blank values in batch encryption and decryption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Vault Rails Changelog
 
+## Unreleased
+
+BUG FIXES
+- Allow blank values like `nil` and empty string as input to batch encryption and decryption (forward ported from 0.6.5)
+- Handle the case when plaintexts/ciphertexts parameter of #vault_batch_encrypt/#vault_batch_decrypt is an array with only blank values (forward ported from 0.6.7)
+
 ## 0.7.2 (December 3, 2018)
 
 NEW FEATURES

--- a/spec/unit/rails_spec.rb
+++ b/spec/unit/rails_spec.rb
@@ -156,6 +156,65 @@ describe Vault::Rails do
 
       expect(Vault::Rails.batch_encrypt('path', 'key', ['plaintext1', 'plaintext2'], Vault::Rails.client)).to eq(%w(ciphertext1 ciphertext2))
     end
+
+    context 'with only blank values' do
+      it 'does not make any calls to Vault and just return the plaintexts' do
+        expect(Vault::Rails.client.logical).not_to receive(:write)
+
+        plaintexts = ['', '', nil, '', nil, nil]
+        expect(Vault::Rails.batch_encrypt('path', 'key', plaintexts, Vault::Rails.client)).to eq(plaintexts)
+      end
+    end
+
+    context 'with presented blank values' do
+      it 'sends the correct parameters to vault client' do
+        expected_route = 'path/encrypt/key'
+        expected_options = {
+          batch_input: [
+            {
+              plaintext: Base64.strict_encode64('plaintext1'),
+              context: Base64.strict_encode64(Vault::Rails.convergent_encryption_context),
+            },
+            {
+              plaintext: Base64.strict_encode64('plaintext2'),
+              context: Base64.strict_encode64(Vault::Rails.convergent_encryption_context),
+            },
+          ],
+          convergent_encryption: true,
+          derived: true
+        }
+
+        expect(Vault::Rails.client.logical).to receive(:write)
+          .with(expected_route, expected_options)
+          .and_return(spy('Vault::Secret'))
+
+        Vault::Rails.batch_encrypt('path', 'key', ['plaintext1', '', 'plaintext2', '', nil, nil], Vault::Rails.client)
+      end
+
+      it 'parses the response from vault client correctly and keeps the order of records' do
+        expected_route = 'path/encrypt/key'
+        expected_options = {
+          batch_input: [
+            {
+              plaintext: Base64.strict_encode64('plaintext1'),
+              context: Base64.strict_encode64(Vault::Rails.convergent_encryption_context),
+            },
+            {
+              plaintext: Base64.strict_encode64('plaintext2'),
+              context: Base64.strict_encode64(Vault::Rails.convergent_encryption_context),
+            },
+          ],
+          convergent_encryption: true,
+          derived: true
+        }
+
+        allow(Vault::Rails.client.logical).to receive(:write)
+          .with(expected_route, expected_options)
+          .and_return(instance_double('Vault::Secret', data: {:batch_results=>[{:ciphertext=>'ciphertext1'}, {:ciphertext=>'ciphertext2'}]}))
+
+        expect(Vault::Rails.batch_encrypt('path', 'key', ['plaintext1', '', 'plaintext2', '', nil], Vault::Rails.client)).to eq(['ciphertext1', '', 'ciphertext2', '', nil])
+      end
+    end
   end
 
   describe '.batch_decrypt' do
@@ -206,6 +265,66 @@ describe Vault::Rails do
         .and_return(instance_double('Vault::Secret', data: {:batch_results=>[{:plaintext=>'cGxhaW50ZXh0MQ=='}, {:plaintext=>'cGxhaW50ZXh0Mg=='}]}))
 
       expect(Vault::Rails.batch_decrypt('path', 'key', ['ciphertext1', 'ciphertext2'], Vault::Rails.client)).to eq( %w(plaintext1 plaintext2)) # in that order
+    end
+
+    context 'with only blank values' do
+      it 'does not make any calls to Vault and just return the ciphertexts' do
+        expect(Vault::Rails.client.logical).not_to receive(:write)
+
+        ciphertexts = ['', '', nil, '', nil, nil]
+
+        expect(Vault::Rails.batch_decrypt('path', 'key', ciphertexts, Vault::Rails.client)).to eq(ciphertexts)
+      end
+    end
+
+    context 'with presented blank values' do
+      it 'sends the correct parameters to vault client' do
+        expected_route = 'path/decrypt/key'
+        expected_options = {
+          batch_input: [
+            {
+              ciphertext: 'ciphertext1',
+              context: Base64.strict_encode64(Vault::Rails.convergent_encryption_context),
+            },
+            {
+              ciphertext: 'ciphertext2',
+              context: Base64.strict_encode64(Vault::Rails.convergent_encryption_context),
+            },
+          ],
+        }
+
+        expect(Vault::Rails.client.logical).to receive(:write)
+          .with(expected_route, expected_options)
+          .and_return(spy('Vault::Secret'))
+
+        Vault::Rails.batch_decrypt('path', 'key', ['ciphertext1', '', 'ciphertext2', nil, '', ''], Vault::Rails.client)
+      end
+
+      it 'parses the response from vault client correctly and keeps the order of records' do
+        expected_route = 'path/decrypt/key'
+        expected_options = {
+          batch_input: [
+            {
+              ciphertext: 'ciphertext1',
+              context: Base64.strict_encode64(Vault::Rails.convergent_encryption_context),
+            },
+            {
+              ciphertext: 'ciphertext2',
+              context: Base64.strict_encode64(Vault::Rails.convergent_encryption_context),
+            },
+            {
+              ciphertext: 'ciphertext3',
+              context: Base64.strict_encode64(Vault::Rails.convergent_encryption_context),
+            },
+          ],
+        }
+
+        allow(Vault::Rails.client.logical).to receive(:write)
+          .with(expected_route, expected_options)
+          .and_return(instance_double('Vault::Secret', data: {batch_results: [{plaintext: 'cGxhaW50ZXh0MQ=='}, {plaintext:'cGxhaW50ZXh0Mg=='}, {plaintext: 'cGxhaW50ZXh0Mw=='}]}))
+
+        expect(Vault::Rails.batch_decrypt('path', 'key', ['ciphertext1', '', nil, 'ciphertext2', '', 'ciphertext3'], Vault::Rails.client)).to eq( ['plaintext1', '', nil, 'plaintext2', '', 'plaintext3']) # in that order
+      end
     end
   end
 end


### PR DESCRIPTION
Forward porting bug fixes for blank values from 0.6-stable branch.

Specifically:

* f631432 - Handle blank values in batch encryption and decryption
* da08d60 - Batch encryption - handle arrays with only blank values
