### PR TITLE
Search by Vault attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,15 +259,23 @@ Even easier, you could use:
 
 ### Searching Encrypted Attributes
 Because each column is uniquely encrypted, it is not possible to search for a
-particular plain-text value. For example, if the `ssn` attribute is encrypted,
+particular plain-text value with a plain `ActiveRecord` query. For example, if the `ssn` attribute is encrypted,
 the following will **NOT** work:
 
 ```ruby
 Person.where(ssn: "123-45-6789")
 ```
 
-This is because the database is unaware of the plain-text data (which is part of
-the security model).
+That's why we have added a method that provides an easy to use search interface. Instead of using `.where` you can use
+`.find_by_vault_attributes`. Example:
+
+```ruby
+Person.find_by_vault_attributes(driving_licence_number: '12345678')
+```
+
+This method will look up seamlessly in the relevant column with encrypted data.
+It is important to note that you can search only for attributes with **convergent** encryption.
+Similar to `.where` the method `.find_by_vault_attributes` also returns an `ActiveRecord::Relation`
 
 ### Uniqueness Validation
 If a column is **convergently** encrypted, it is possible to add a validation of uniqueness to it.

--- a/lib/vault/encrypted_model.rb
+++ b/lib/vault/encrypted_model.rb
@@ -116,7 +116,7 @@ module Vault
         self
       end
 
-      # Encrypt Vault attribures before saving them
+      # Encrypt Vault attributes before saving them
       def vault_persist_before_save!
         skip_callback :save, :after, :__vault_persist_attributes!
         before_save :__vault_encrypt_attributes!
@@ -185,6 +185,23 @@ module Vault
         plaintext = serializer ? serializer.encode(value) : value
 
         Vault::Rails.encrypt(path, key, plaintext, Vault.client, convergent)
+      end
+
+      def find_by_vault_attributes(attributes)
+        search_options = {}
+
+        attributes.each do |attribute_name, attribute_value|
+          attribute_options = __vault_attributes[attribute_name]
+          encrypted_column = attribute_options[:encrypted_column]
+
+          unless attribute_options[:convergent]
+            raise ArgumentError, 'You cannot search with non-convergent fields'
+          end
+
+          search_options[encrypted_column] = encrypt_value(attribute_name, attribute_value)
+        end
+
+        where(search_options)
       end
     end
 

--- a/spec/integration/rails_spec.rb
+++ b/spec/integration/rails_spec.rb
@@ -601,4 +601,41 @@ describe Vault::Rails do
       end
     end
   end
+
+  describe '.find_by_vault_attributes' do
+    before do
+      allow(Vault::Rails).to receive(:convergent_encryption_context).and_return('a' * 16).at_least(:once)
+    end
+
+    it 'finds the expected records' do
+      first_person = LazyPerson.create!(passport_number: '12345678')
+      second_person = LazyPerson.create!(passport_number: '12345678')
+      third_person = LazyPerson.create!(passport_number: '87654321')
+
+      expect(LazyPerson.find_by_vault_attributes(passport_number: '12345678').pluck(:id)).to match_array([first_person, second_person].map(&:id))
+    end
+
+    context 'searching by attributes with defined serializer' do
+      it 'finds the expected records' do
+        first_person = Person.create!(ip_address: IPAddr.new('127.0.0.1'))
+        second_person = Person.create!(ip_address: IPAddr.new('192.168.0.1'))
+
+        expect(Person.find_by_vault_attributes(ip_address: IPAddr.new('127.0.0.1')).pluck(:id)).to match_array([first_person.id])
+      end
+    end
+
+    context 'searching by multiple attributes' do
+      it 'finds the expected records' do
+        first_person = Person.create!(ip_address: IPAddr.new('127.0.0.1'), driving_licence_number: '12345678')
+
+        expect(Person.find_by_vault_attributes(ip_address: IPAddr.new('127.0.0.1'), driving_licence_number: '12345678').pluck(:id)).to match_array([first_person.id])
+      end
+    end
+
+    context 'non-convergently encrypted attributes' do
+      it 'raises an exception' do
+        expect { LazyPerson.find_by_vault_attributes(ssn: '12345678') }.to raise_error('You cannot search with non-convergent fields')
+      end
+    end
+  end
 end


### PR DESCRIPTION
Searching by Vault attributes with SQL  could be cumbersome and requires several preprocessing operations like serialization and encryption.

All of the above can be combined in a search method.
The `.find_by_vault_attributes` method receives a hash of arguments as input and returns the `ActiveRecord::Relation`, which contains the expected records.

/cc @FundingCircle/gdpr-engineering 👀 

P.S I want to add tests that include queries with multiple fields, but at the moment only one convergent field exists per class. More convergent fields will come from #52 and then I can reuse them.
