### PR TITLE
Add validation option for persisting in batches

### DIFF
--- a/lib/vault/perform_in_batches.rb
+++ b/lib/vault/perform_in_batches.rb
@@ -10,7 +10,7 @@ module Vault
       @convergent = options[:convergent]
     end
 
-    def encrypt(records, plaintexts)
+    def encrypt(records, plaintexts, validate: true)
       raise 'Batch Operations work only with convergent attributes' unless @convergent
 
       raw_plaintexts = serialize(plaintexts)
@@ -19,7 +19,7 @@ module Vault
 
       records.each_with_index do |record, index|
         record.send("#{column}=", ciphertexts[index])
-        record.save
+        record.save(validate: validate)
       end
     end
 

--- a/spec/unit/perform_in_batches_spec.rb
+++ b/spec/unit/perform_in_batches_spec.rb
@@ -53,6 +53,31 @@ describe Vault::PerformInBatches do
         Vault::PerformInBatches.new(attribute, options).encrypt(records, plaintexts)
       end
 
+      context 'with validation turned off' do
+        it 'encrypts one attribute for a batch of records and saves it without validations' do
+          attribute = 'test_attribute'
+
+          first_record = double(save: true)
+          second_record = double(save: true)
+          records = [first_record, second_record]
+
+          plaintexts = %w(plaintext1 plaintext2)
+
+
+          expect(Vault::Rails).to receive(:batch_encrypt)
+            .with('test_path', 'test_key', %w(plaintext1 plaintext2), Vault.client)
+            .and_return(%w(ciphertext1 ciphertext2))
+
+          expect(first_record).to receive('test_attribute_encrypted=').with('ciphertext1')
+          expect(second_record).to receive('test_attribute_encrypted=').with('ciphertext2')
+
+          expect(first_record).to receive(:save).with(validate: false)
+          expect(second_record).to receive(:save).with(validate: false)
+
+          Vault::PerformInBatches.new(attribute, options).encrypt(records, plaintexts, validate: false)
+        end
+      end
+
       context 'with given serializer' do
         let(:options) do
           {


### PR DESCRIPTION
Sometimes we might want to persist the encrypted value even for invalid objects
By default, objects are still saved with validations.

/cc @elenatanasoiu 👀 