### PR TITLE
Add validate option to vault_persist_all

### DIFF
--- a/lib/vault/encrypted_model.rb
+++ b/lib/vault/encrypted_model.rb
@@ -159,10 +159,10 @@ module Vault
       end
 
       # works only with convergent encryption
-      def vault_persist_all(attribute, records, plaintexts)
+      def vault_persist_all(attribute, records, plaintexts, validate: true)
         options = __vault_attributes[attribute]
 
-        Vault::PerformInBatches.new(attribute, options).encrypt(records, plaintexts)
+        Vault::PerformInBatches.new(attribute, options).encrypt(records, plaintexts, validate: validate)
       end
 
       # works only with convergent encryption

--- a/spec/integration/rails_spec.rb
+++ b/spec/integration/rails_spec.rb
@@ -599,6 +599,17 @@ describe Vault::Rails do
         expect(first_person.reload.passport_number).to eq('12345678')
         expect(second_person.reload.passport_number).to eq('12345679')
       end
+
+      context 'skipped validations' do
+        it 'saves even invalid records' do
+          first_person = LazyPerson.new
+          allow(first_person).to receive(:valid?).and_return(false)
+
+          LazyPerson.vault_persist_all(:passport_number, [first_person], %w(12345678), validate: false)
+
+          expect(first_person.reload.passport_number).to eq('12345678')
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Adding the validation option introduced in #59 also to `EncryptedModel.vault_persist_all`

/cc @elenatanasoiu 👀 