### PR TITLE
Cleanse error messages when uniqueness validation is used

### DIFF
--- a/lib/vault/rails/vault_uniqueness_validator.rb
+++ b/lib/vault/rails/vault_uniqueness_validator.rb
@@ -13,11 +13,20 @@ class VaultUniquenessValidator < ActiveRecord::Validations::UniquenessValidator
     encrypted_value = record.class.encrypt_value(attribute, value)
 
     super(record, encrypted_column, encrypted_value)
+
+    cleanse_error_message(record, attribute, encrypted_column, encrypted_value)
   end
 
   private
 
   def vault_options(record, attribute)
     record.class.__vault_attributes[attribute]
+  end
+
+  def cleanse_error_message(record, attribute, encrypted_column, encrypted_value)
+    return unless record.errors.key?(encrypted_column.to_sym)
+
+    record.errors.delete(encrypted_column.to_sym)
+    record.errors.add(attribute, :taken, value: encrypted_value)
   end
 end

--- a/spec/integration/rails_spec.rb
+++ b/spec/integration/rails_spec.rb
@@ -515,6 +515,8 @@ describe Vault::Rails do
         same_driving_licence_number_person = Person.new(driving_licence_number: '12345678')
 
         expect(same_driving_licence_number_person).not_to be_valid
+        expect(same_driving_licence_number_person.errors[:driving_licence_number]).to include('has already been taken')
+        expect(same_driving_licence_number_person.errors[:driving_licence_number_encrypted]).not_to include('has already been taken')
       end
     end
 


### PR DESCRIPTION
This PR solves the issue where the validation error message for uniqueness would include a non user friendly key for the message e.g. `Driving License Number Encrypted has been taken`. It now uses the `vault_attribute` name.

/cc @FundingCircle/gdpr-engineering 

