### PR TITLE
Updates find_by and where searching for encrypted fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,16 @@
 # Vault Rails Changelog
+## 1.0.0 (March 8, 2019)
+
+NEW FEATURES
+- Added `encrypted_find_by` finds the first encrypted record matching the specified conditions
+- Added `encrypted_find_by!` like `encrypted_find_by`, except that if no record is found, raises an `ActiveRecord::RecordNotFound` error.
+
+IMPROVEMENTS
+- `find_by_vault_attributes` renamed to `encrypted_where` as it returns a relation rather than a single record
+
+BREAKING CHANGES
+- `find_by_vault_attributes` renamed to `encrypted_where`
+
 ## 0.7.7 (March 6, 2019)
 
 IMPROVEMENTS

--- a/README.md
+++ b/README.md
@@ -294,15 +294,27 @@ Person.where(ssn: "123-45-6789")
 ```
 
 That's why we have added a method that provides an easy to use search interface. Instead of using `.where` you can use
-`.find_by_vault_attributes`. Example:
+`.encrypted_where`. Example:
 
 ```ruby
-Person.find_by_vault_attributes(driving_licence_number: '12345678')
+Person.encrypted_where(driving_licence_number: '12345678')
 ```
 
 This method will look up seamlessly in the relevant column with encrypted data.
 It is important to note that you can search only for attributes with **convergent** encryption.
-Similar to `.where` the method `.find_by_vault_attributes` also returns an `ActiveRecord::Relation`
+Similar to `.where` the method `.encrypted_where` also returns an `ActiveRecord::Relation`
+
+There is also `.encrypted_find_by` which works like `.find_by` finds the first encrypted record matching the specified conditions
+
+```ruby
+Personal.encrypted_find_by(driving_licence_number: '12345678')
+```
+
+and `.encrypted_find_by!` like `encrypted_find_by`, except that if no record is found, raises an `ActiveRecord::RecordNotFound` error.
+
+```ruby
+Personal.encrypted_find_by!(driving_licence_number: '12345678')
+```
 
 ### Uniqueness Validation
 If a column is **convergently** encrypted, it is possible to add a validation of uniqueness to it.

--- a/gemfiles/rails_5.0.gemfile.lock
+++ b/gemfiles/rails_5.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    fc-vault-rails (0.7.7)
+    fc-vault-rails (1.0.0)
       activerecord (>= 5.0.0, < 6.0)
       vault (~> 0.7)
 

--- a/gemfiles/rails_5.1.gemfile.lock
+++ b/gemfiles/rails_5.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    fc-vault-rails (0.7.7)
+    fc-vault-rails (1.0.0)
       activerecord (>= 5.0.0, < 6.0)
       vault (~> 0.7)
 

--- a/gemfiles/rails_5.2.gemfile.lock
+++ b/gemfiles/rails_5.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    fc-vault-rails (0.7.7)
+    fc-vault-rails (1.0.0)
       activerecord (>= 5.0.0, < 6.0)
       vault (~> 0.7)
 

--- a/lib/vault/encrypted_model.rb
+++ b/lib/vault/encrypted_model.rb
@@ -241,21 +241,33 @@ module Vault
         Vault::Rails.encrypt(path, key, plaintext, Vault.client, convergent)
       end
 
-      def find_by_vault_attributes(attributes)
-        search_options = {}
+      def encrypted_find_by(attributes)
+        find_by(search_options(attributes))
+      end
 
-        attributes.each do |attribute_name, attribute_value|
-          attribute_options = __vault_attributes[attribute_name]
-          encrypted_column = attribute_options[:encrypted_column]
+      def encrypted_find_by!(attributes)
+        find_by!(search_options(attributes))
+      end
 
-          unless attribute_options[:convergent]
-            raise ArgumentError, 'You cannot search with non-convergent fields'
+      def encrypted_where(attributes)
+        where(search_options(attributes))
+      end
+
+      private
+
+      def search_options(attributes)
+        {}.tap do |search_options|
+          attributes.each do |attribute_name, attribute_value|
+            attribute_options = __vault_attributes[attribute_name]
+            encrypted_column = attribute_options[:encrypted_column]
+
+            unless attribute_options[:convergent]
+              raise ArgumentError, 'You cannot search with non-convergent fields'
+            end
+
+            search_options[encrypted_column] = encrypt_value(attribute_name, attribute_value)
           end
-
-          search_options[encrypted_column] = encrypt_value(attribute_name, attribute_value)
         end
-
-        where(search_options)
       end
     end
 

--- a/lib/vault/rails/version.rb
+++ b/lib/vault/rails/version.rb
@@ -1,5 +1,5 @@
 module Vault
   module Rails
-    VERSION = "0.7.7"
+    VERSION = "1.0.0"
   end
 end


### PR DESCRIPTION
Bumps version from 0.7.7 to 1.0.0

Adds:

- Added `encrypted_find_by` finds the first encrypted record matching the specified conditions
- Added `encrypted_find_by!` like `encrypted_find_by`, except that if no record is found, raises an `ActiveRecord::RecordNotFound` error.

Changes:

- `find_by_vault_attributes` to `encrypted_where` as it returns a relation rather than a single record. **(BREAKING)**

/cc @FundingCircle/gdpr-engineering 

Happy to discuss changing the method names if anyone can think of something better (I couldn't)