### PR TITLE
Updates find_by and where searching for encrypted fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Vault Rails Changelog
 
+## v0.6.11 (March 8, 2019)
+
+NEW FEATURES
+- Added `encrypted_find_by` finds the first encrypted record matching the specified conditions
+- Added `encrypted_find_by!` like `encrypted_find_by`, except that if no record is found, raises an `ActiveRecord::RecordNotFound` error.
+
+IMPROVEMENTS
+- `find_by_vault_attributes` renamed to `encrypted_where` as it returns a relation rather than a single record
+
+BREAKING CHANGES
+- `find_by_vault_attributes` renamed to `encrypted_where`
+
 ## v0.6.10 (March 6, 2019)
 
 IMPROVEMENTS

--- a/README.md
+++ b/README.md
@@ -269,15 +269,27 @@ Person.where(ssn: "123-45-6789")
 ```
 
 That's why we have added a method that provides an easy to use search interface. Instead of using `.where` you can use
-`.find_by_vault_attributes`. Example:
+`.encrypted_where`. Example:
 
 ```ruby
-Person.find_by_vault_attributes(driving_licence_number: '12345678')
+Person.encrypted_where(driving_licence_number: '12345678')
 ```
 
 This method will look up seamlessly in the relevant column with encrypted data.
 It is important to note that you can search only for attributes with **convergent** encryption.
-Similar to `.where` the method `.find_by_vault_attributes` also returns an `ActiveRecord::Relation`
+Similar to `.where` the method `.encrypted_where` also returns an `ActiveRecord::Relation`
+
+There is also `.encrypted_find_by` which works like `.find_by` finds the first encrypted record matching the specified conditions
+
+```ruby
+Personal.encrypted_find_by(driving_licence_number: '12345678')
+```
+
+and `.encrypted_find_by!` like `encrypted_find_by`, except that if no record is found, raises an `ActiveRecord::RecordNotFound` error.
+
+```ruby
+Personal.encrypted_find_by!(driving_licence_number: '12345678')
+```
 
 ### Uniqueness Validation
 If a column is **convergently** encrypted, it is possible to add a validation of uniqueness to it.

--- a/gemfiles/rails_4.2.gemfile.lock
+++ b/gemfiles/rails_4.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    fc-vault-rails (0.6.10)
+    fc-vault-rails (0.6.11)
       activerecord (>= 4.2, < 5.0)
       vault (~> 0.7)
 

--- a/lib/vault/encrypted_model.rb
+++ b/lib/vault/encrypted_model.rb
@@ -187,21 +187,33 @@ module Vault
         Vault::Rails.encrypt(path, key, plaintext, Vault.client, convergent)
       end
 
-      def find_by_vault_attributes(attributes)
-        search_options = {}
+      def encrypted_find_by(attributes)
+        find_by(search_options(attributes))
+      end
 
-        attributes.each do |attribute_name, attribute_value|
-          attribute_options = __vault_attributes[attribute_name]
-          encrypted_column = attribute_options[:encrypted_column]
+      def encrypted_find_by!(attributes)
+        find_by!(search_options(attributes))
+      end
 
-          unless attribute_options[:convergent]
-            raise ArgumentError, 'You cannot search with non-convergent fields'
+      def encrypted_where(attributes)
+        where(search_options(attributes))
+      end
+
+      private
+
+      def search_options(attributes)
+        {}.tap do |search_options|
+          attributes.each do |attribute_name, attribute_value|
+            attribute_options = __vault_attributes[attribute_name]
+            encrypted_column = attribute_options[:encrypted_column]
+
+            unless attribute_options[:convergent]
+              raise ArgumentError, 'You cannot search with non-convergent fields'
+            end
+
+            search_options[encrypted_column] = encrypt_value(attribute_name, attribute_value)
           end
-
-          search_options[encrypted_column] = encrypt_value(attribute_name, attribute_value)
         end
-
-        where(search_options)
       end
     end
 

--- a/lib/vault/rails/version.rb
+++ b/lib/vault/rails/version.rb
@@ -1,5 +1,5 @@
 module Vault
   module Rails
-    VERSION = "0.6.10"
+    VERSION = "0.6.11"
   end
 end

--- a/spec/integration/rails_spec.rb
+++ b/spec/integration/rails_spec.rb
@@ -615,7 +615,87 @@ describe Vault::Rails do
     end
   end
 
-  describe '.find_by_vault_attributes' do
+  describe '.encrypted_find_by' do
+    before do
+      allow(Vault::Rails).to receive(:convergent_encryption_context).and_return('a' * 16).at_least(:once)
+    end
+
+    it 'finds the expected record' do
+      first_person = LazyPerson.create!(passport_number: '12345678')
+      second_person = LazyPerson.create!(passport_number: '12345678')
+      third_person = LazyPerson.create!(passport_number: '87654321')
+
+      expect(LazyPerson.encrypted_find_by(passport_number: '12345678')).to eq(first_person)
+    end
+
+    context 'searching by attributes with defined serializer' do
+      it 'finds the expected record' do
+        first_person = Person.create!(ip_address: IPAddr.new('127.0.0.1'))
+        second_person = Person.create!(ip_address: IPAddr.new('192.168.0.1'))
+
+        expect(Person.encrypted_find_by(ip_address: IPAddr.new('127.0.0.1'))).to eq(first_person)
+      end
+    end
+
+    context 'searching by multiple attributes' do
+      it 'finds the expected record' do
+        first_person = Person.create!(ip_address: IPAddr.new('127.0.0.1'), driving_licence_number: '12345678')
+
+        expect(Person.encrypted_find_by(ip_address: IPAddr.new('127.0.0.1'), driving_licence_number: '12345678')).to eq(first_person)
+      end
+    end
+
+    context 'non-convergently encrypted attributes' do
+      it 'raises an exception' do
+        expect { LazyPerson.encrypted_find_by(ssn: '12345678') }.to raise_error('You cannot search with non-convergent fields')
+      end
+    end
+  end
+
+  describe '.encrypted_find_by!' do
+    before do
+      allow(Vault::Rails).to receive(:convergent_encryption_context).and_return('a' * 16).at_least(:once)
+    end
+
+    it 'finds the expected record' do
+      first_person = LazyPerson.create!(passport_number: '12345678')
+      second_person = LazyPerson.create!(passport_number: '12345678')
+      third_person = LazyPerson.create!(passport_number: '87654321')
+
+      expect(LazyPerson.encrypted_find_by!(passport_number: '12345678')).to eq(first_person)
+    end
+
+    context 'searching by attributes with defined serializer' do
+      it 'finds the expected record' do
+        first_person = Person.create!(ip_address: IPAddr.new('127.0.0.1'))
+        second_person = Person.create!(ip_address: IPAddr.new('192.168.0.1'))
+
+        expect(Person.encrypted_find_by!(ip_address: IPAddr.new('127.0.0.1'))).to eq(first_person)
+      end
+    end
+
+    context 'searching by multiple attributes' do
+      it 'finds the expected record' do
+        first_person = Person.create!(ip_address: IPAddr.new('127.0.0.1'), driving_licence_number: '12345678')
+
+        expect(Person.encrypted_find_by!(ip_address: IPAddr.new('127.0.0.1'), driving_licence_number: '12345678')).to eq(first_person)
+      end
+    end
+
+    context 'searching missing record' do
+      it 'raises an exception' do
+        expect { LazyPerson.encrypted_find_by!(passport_number: '000') }.to raise_exception(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    context 'non-convergently encrypted attributes' do
+      it 'raises an exception' do
+        expect { LazyPerson.encrypted_find_by!(ssn: '12345678') }.to raise_error('You cannot search with non-convergent fields')
+      end
+    end
+  end
+
+  describe '.encrypted_where' do
     before do
       allow(Vault::Rails).to receive(:convergent_encryption_context).and_return('a' * 16).at_least(:once)
     end
@@ -625,7 +705,7 @@ describe Vault::Rails do
       second_person = LazyPerson.create!(passport_number: '12345678')
       third_person = LazyPerson.create!(passport_number: '87654321')
 
-      expect(LazyPerson.find_by_vault_attributes(passport_number: '12345678').pluck(:id)).to match_array([first_person, second_person].map(&:id))
+      expect(LazyPerson.encrypted_where(passport_number: '12345678').pluck(:id)).to match_array([first_person, second_person].map(&:id))
     end
 
     context 'searching by attributes with defined serializer' do
@@ -633,7 +713,7 @@ describe Vault::Rails do
         first_person = Person.create!(ip_address: IPAddr.new('127.0.0.1'))
         second_person = Person.create!(ip_address: IPAddr.new('192.168.0.1'))
 
-        expect(Person.find_by_vault_attributes(ip_address: IPAddr.new('127.0.0.1')).pluck(:id)).to match_array([first_person.id])
+        expect(Person.encrypted_where(ip_address: IPAddr.new('127.0.0.1')).pluck(:id)).to match_array([first_person.id])
       end
     end
 
@@ -641,13 +721,13 @@ describe Vault::Rails do
       it 'finds the expected records' do
         first_person = Person.create!(ip_address: IPAddr.new('127.0.0.1'), driving_licence_number: '12345678')
 
-        expect(Person.find_by_vault_attributes(ip_address: IPAddr.new('127.0.0.1'), driving_licence_number: '12345678').pluck(:id)).to match_array([first_person.id])
+        expect(Person.encrypted_where(ip_address: IPAddr.new('127.0.0.1'), driving_licence_number: '12345678').pluck(:id)).to match_array([first_person.id])
       end
     end
 
     context 'non-convergently encrypted attributes' do
       it 'raises an exception' do
-        expect { LazyPerson.find_by_vault_attributes(ssn: '12345678') }.to raise_error('You cannot search with non-convergent fields')
+        expect { LazyPerson.encrypted_where(ssn: '12345678') }.to raise_error('You cannot search with non-convergent fields')
       end
     end
   end


### PR DESCRIPTION
Bumps version from 0.6.10 to 0.6.11

Adds:

* Added `encrypted_find_by` finds the first encrypted record matching the specified conditions
* Added `encrypted_find_by!` like `encrypted_find_by`, except that if no record is found, raises an `ActiveRecord::RecordNotFound` error.

Changes:

* `find_by_vault_attributes` to `encrypted_where` as it returns a relation rather than a single record. **(BREAKING)**

/cc @FundingCircle/gdpr-engineering

Happy to discuss changing the method names if anyone can think of something better (I couldn't)