### PR TITLE
Adds encrypted_where_not

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Vault Rails Changelog
 
+## v0.6.12 (March 14, 2019)
+
+NEW FEATURES
+- Added `encrypted_where_not` finds encrypted records not matching the specified conditions
+
 ## v0.6.11 (March 8, 2019)
 
 NEW FEATURES

--- a/README.md
+++ b/README.md
@@ -279,7 +279,9 @@ This method will look up seamlessly in the relevant column with encrypted data.
 It is important to note that you can search only for attributes with **convergent** encryption.
 Similar to `.where` the method `.encrypted_where` also returns an `ActiveRecord::Relation`
 
-There is also `.encrypted_find_by` which works like `.find_by` finds the first encrypted record matching the specified conditions
+Along with `.encrypted_where` we also have `.encrypted_where_not` which finds encrypted records not matching the specified conditions acts like `.where.not`
+
+There is also `.encrypted_find_by` which works like `.find_by` finds the first encrypted record matching the specified conditions.
 
 ```ruby
 Personal.encrypted_find_by(driving_licence_number: '12345678')

--- a/gemfiles/rails_4.2.gemfile.lock
+++ b/gemfiles/rails_4.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    fc-vault-rails (0.6.11)
+    fc-vault-rails (0.6.12)
       activerecord (>= 4.2, < 5.0)
       vault (~> 0.7)
 

--- a/lib/vault/encrypted_model.rb
+++ b/lib/vault/encrypted_model.rb
@@ -199,6 +199,10 @@ module Vault
         where(search_options(attributes))
       end
 
+      def encrypted_where_not(attributes)
+        where.not(search_options(attributes))
+      end
+
       private
 
       def search_options(attributes)

--- a/lib/vault/rails/version.rb
+++ b/lib/vault/rails/version.rb
@@ -1,5 +1,5 @@
 module Vault
   module Rails
-    VERSION = "0.6.11"
+    VERSION = "0.6.12"
   end
 end

--- a/spec/integration/rails_spec.rb
+++ b/spec/integration/rails_spec.rb
@@ -731,4 +731,18 @@ describe Vault::Rails do
       end
     end
   end
+
+  describe '.encrypted_where_not' do
+    before do
+      allow(Vault::Rails).to receive(:convergent_encryption_context).and_return('a' * 16).at_least(:once)
+    end
+
+    it 'finds the expected records' do
+      first_person = LazyPerson.create!(passport_number: '12345678')
+      second_person = LazyPerson.create!(passport_number: '12345678')
+      third_person = LazyPerson.create!(passport_number: '87654321')
+
+      expect(LazyPerson.encrypted_where_not(passport_number: nil).pluck(:id)).to match_array([first_person, second_person, third_person].map(&:id))
+    end
+  end
 end


### PR DESCRIPTION
Bumps version from 0.6.11 to 0.6.12

Adds:

Added `encrypted_where_not` finds encrypted records not matching the specified conditions

/cc @FundingCircle/gdpr-engineering