### PR TITLE
Fix deprecation warning for Rails 5.1

### DIFF
--- a/lib/vault/encrypted_model.rb
+++ b/lib/vault/encrypted_model.rb
@@ -363,13 +363,13 @@ module Vault
         # Only persist changed attributes to minimize requests - this helps
         # minimize the number of requests to Vault.
 
-        if in_after_save && ActiveRecord.version >= Gem::Version.new('5.2.0')
+        if in_after_save && ActiveRecord.version >= Gem::Version.new('5.1.0')
           # ActiveRecord 5.2 changes the behaviour of `changed` in `after_*` callbacks
           # https://www.ombulabs.com/blog/rails/upgrades/active-record-5-1-api-changes.html
           # https://api.rubyonrails.org/classes/ActiveRecord/AttributeMethods/Dirty.html#method-i-saved_change_to_attribute
           return unless saved_change_to_attribute?(attribute)
         else
-          # Rails >= 4.2.8 and <= 5.1
+          # Rails >= 4.2.8 and < 5.1
           return unless changed.include?("#{attribute}")
         end
 

--- a/spec/dummy/db/migrate/20150428220101_create_people.rb
+++ b/spec/dummy/db/migrate/20150428220101_create_people.rb
@@ -1,4 +1,4 @@
-class CreatePeople < ActiveRecord::Migration
+class CreatePeople < ActiveRecord::Migration[5.0]
   def change
     create_table :people do |t|
       t.string :name


### PR DESCRIPTION
A code change was introduced here https://github.com/FundingCircle/fc-vault-rails/commit/bdb80c84a7bf0bb2c9101a6dd1c7316dd955666f to fix a deprecation that causes breaking code in rails version 5.2. This change should apply to rails version 5.1 as well so the related deprecation warnings are not produced.

Also specified the rails version for the first migration as it is required in rails post 5.0. Specified 5.0 to match other migration files and reflect the gems supported versions of rails