### PR TITLE
Fixes bug with memory decryption not handing blank values

### DIFF
--- a/lib/vault/rails.rb
+++ b/lib/vault/rails.rb
@@ -220,7 +220,7 @@ module Vault
       def memory_decrypt(path, key, ciphertext, _client, convergent)
         log_warning(DEV_WARNING) if self.in_memory_warnings_enabled?
 
-        return nil if ciphertext.nil?
+        return ciphertext if ciphertext.blank?
 
         cipher = OpenSSL::Cipher::AES.new(128, :CBC)
         cipher.decrypt

--- a/spec/integration/rails_spec.rb
+++ b/spec/integration/rails_spec.rb
@@ -518,6 +518,20 @@ describe Vault::Rails do
         expect(first_person.email_encrypted).not_to eq(second_person.email_encrypted)
       end
     end
+
+    context '.vault_load_all' do
+      it 'works with records with nil and blank values' do
+        first_person = LazyPerson.create!(passport_number: nil)
+        second_person = LazyPerson.create!(passport_number: '')
+
+        first_person.reload
+        second_person.reload
+
+        LazyPerson.vault_load_all(:passport_number, [first_person, second_person])
+        expect(first_person.passport_number).to eq(nil)
+        expect(second_person.passport_number).to eq('')
+      end
+    end
   end
 
   context 'uniqueness validation' do


### PR DESCRIPTION
When `Vault::Rails.enabled` is `false` in-memory decryption/encryption is used.

There was an error where when the ciphertext was a blank string in tests  https://github.com/FundingCircle/fc-vault-rails/blob/master/lib/vault/rails.rb#L229 would cause the code to raise a error of `ArgumentError: iv must be 16 bytes`.

This fixes the issue by returning the ciphertext if the ciphertext is blank

/cc @FundingCircle/gdpr-engineering 