### PR TITLE
Version 2.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Vault Rails Changelog
+## 2.0.2 (May 16, 2019)
+
+IMPROVEMENTS
+- Fixes issue when a blank string ciphertext is used by the `memory_decrypt` method.
+
 ## 2.0.1 (May 2, 2019)
 
 NEW FEATURES

--- a/gemfiles/rails_4.2.gemfile.lock
+++ b/gemfiles/rails_4.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    fc-vault-rails (2.0.1)
+    fc-vault-rails (2.0.2)
       activerecord (>= 4.2, < 6.0)
       vault (~> 0.7)
 

--- a/gemfiles/rails_5.0.gemfile.lock
+++ b/gemfiles/rails_5.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    fc-vault-rails (2.0.1)
+    fc-vault-rails (2.0.2)
       activerecord (>= 4.2, < 6.0)
       vault (~> 0.7)
 

--- a/gemfiles/rails_5.1.gemfile.lock
+++ b/gemfiles/rails_5.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    fc-vault-rails (2.0.1)
+    fc-vault-rails (2.0.2)
       activerecord (>= 4.2, < 6.0)
       vault (~> 0.7)
 

--- a/gemfiles/rails_5.2.gemfile.lock
+++ b/gemfiles/rails_5.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    fc-vault-rails (2.0.1)
+    fc-vault-rails (2.0.2)
       activerecord (>= 4.2, < 6.0)
       vault (~> 0.7)
 

--- a/lib/vault/rails/version.rb
+++ b/lib/vault/rails/version.rb
@@ -1,6 +1,6 @@
 module Vault
   module Rails
-    VERSION = "2.0.1"
+    VERSION = "2.0.2"
 
     def self.latest?
       ActiveRecord.version >= Gem::Version.new('5.0.0')


### PR DESCRIPTION
Bumps version from 2.0.1 to 2.0.2

IMPROVEMENTS
- Fixes issue when a blank string ciphertext is used by the `memory_decrypt` method.

/cc @FundingCircle/gdpr-engineering 