### PR TITLE
Update JSONSerializer when encoding to return value if already a JSON…

### DIFF
--- a/lib/vault/rails/serializers/json_serializer.rb
+++ b/lib/vault/rails/serializers/json_serializer.rb
@@ -11,8 +11,10 @@ module Vault
 
         def self.encode(raw)
           return if raw.nil?
+          return raw if raw.is_a?(String)
           JSON.fast_generate(raw)
         end
+
 
         def self.decode(raw)
           return if raw.nil?

--- a/spec/unit/rails/serializers/json_serializer_spec.rb
+++ b/spec/unit/rails/serializers/json_serializer_spec.rb
@@ -1,11 +1,19 @@
 require 'spec_helper'
 
 describe Vault::Rails::Serializers::JSONSerializer do
-  it 'encodes values to strings' do
-    expect(subject.encode({"foo" => "bar", "baz" => 1})).to eq '{"foo":"bar","baz":1}'
+  context '.encode' do
+    it 'encodes values to strings' do
+      expect(subject.encode({"foo" => "bar", "baz" => 1})).to eq '{"foo":"bar","baz":1}'
+    end
+
+    it 'returns values already encoded as a JSON string' do
+      expect(subject.encode('{"anonymised":true}')).to eq('{"anonymised":true}')
+    end
   end
 
-  it 'decodes values from strings' do
-    expect(subject.decode('{"foo":"bar","baz":1}')).to eq({"foo" => "bar", "baz" => 1})
+  context '.decode' do
+    it 'decodes values from strings' do
+      expect(subject.decode('{"foo":"bar","baz":1}')).to eq({"foo" => "bar", "baz" => 1})
+    end
   end
 end


### PR DESCRIPTION
… string

In some cases a string could be passed to `encode` in this case we can ignore converting to a JSON string as it should already be one

/cc @FundingCircle/gdpr-engineering 