### PR TITLE
Introduce encrypted copy feature

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,7 +128,7 @@ jobs:
 
       - run:
           shell: /bin/bash -l
-          command: rvm use --default 2.5.1
+          command: rvm use --default 2.5.7
 
       - run:
           name: Install Gem Versioner
@@ -165,7 +165,7 @@ jobs:
 
       - run:
           shell: /bin/bash -l
-          command: rvm use --default 2.5.1
+          command: rvm use --default 2.5.7
 
       - run:
           name: Install Gem Versioner

--- a/README.md
+++ b/README.md
@@ -188,6 +188,23 @@ vault_attribute :address,
 VaultRails decrypts all the encrypted attributes in an `after_initialize` callback. Although this is useful sometimes, other times it may be unnecessary. For example you may not need all or any of the encrypted attributes.
 In such cases, you can use `vault_lazy_decrypt!` in your model, and VaultRails will decrypt the attributes, one by one, only when they are needed.
 
+### Encrypted copy
+The encrypted copy option allows you to have an additional ciphertext column which is encrypted with a additional key. This means that the data will be encrypted twice - once with the column/model-based key and additionally with another custom key. You can specify the additional ciphertext column and encryption key like this:
+
+```ruby
+vault_attribute :first_name,
+  encrypted_copy: {
+    column: 'first_name_user_based_encrypted',
+    key: -> { "#{user_uuid}_key" }
+  }
+```
+
+In this example `first_name_user_based_encrypted` is the additional ciphertext field.
+The key that is used to encrypt the ciphertext contains `user_uuid` which means the encryption key is unique per user. That key is saved on an additional column called `encryption_metadata`.
+Besides the additional two columns the rest of the encryption/decryption logic stays the same - there is `first_name_encrypted` column which contains ciphertext encrypted with `#{app}_#{table}_#{column}` default key, which is also used during decryption (the encrypted copy is not used for decryption).
+
+The purpose of the encrypted copy would be to have another version of the data encrypted by user key and provide both the ciphertext and the key together for other services to consume.
+
 Caveats
 -------
 

--- a/lib/vault/latest/encrypted_model.rb
+++ b/lib/vault/latest/encrypted_model.rb
@@ -81,6 +81,11 @@ module Vault
 
           serializer = _vault_fetch_serializer(options, attribute_type)
 
+          # Encrypted copy serialization
+          if encrypted_copy
+            serialize :encryption_metadata, JSON
+          end
+
           # Make a note of this attribute so we can use it in the future (maybe).
           __vault_attributes[attribute_name.to_sym] = {
             key: key,
@@ -165,9 +170,9 @@ module Vault
           end
 
           if options[:encrypted_copy]
-            if options[:encrypted_copy][:column].nil? || options[:encrypted_copy][:key_column].nil?
+            if options[:encrypted_copy][:column].nil? || options[:encrypted_copy][:key].nil?
               raise Vault::Rails::ValidationFailedError, "Cannot specify " \
-                "`:encrypted_copy` with missing `:column` or `:key_column`"
+                "`:encrypted_copy` with missing `:column` or `:key`"
             end
           end
         end
@@ -361,9 +366,16 @@ module Vault
           changes = {}
 
           self.class.__vault_attributes.each do |attribute, options|
-            if c = self.__vault_encrypt_attribute!(attribute, options, in_after_save: in_after_save)
-              changes.merge!(c)
+            if change = self.__vault_encrypt_attribute!(attribute, options, in_after_save: in_after_save)
+              changes.merge!(change) { |_, old_value, new_value| old_value + new_value }
             end
+          end
+
+          if changes[:encryption_metadata]
+            encryption_metadata_with_changes = __vault_merge_encryption_metadata_changes(changes[:encryption_metadata])
+
+            changes[:encryption_metadata] = encryption_metadata_with_changes
+            write_attribute(:encryption_metadata, encryption_metadata_with_changes)
           end
 
           changes
@@ -401,11 +413,12 @@ module Vault
           result = { column => ciphertext }
 
           if options[:encrypted_copy]
-            key = self.send(options[:encrypted_copy][:key_column])
-            encryption_options = self.class.__vault_attributes[attribute].merge({ key: key })
+            encryption_metadata = __vault_get_encryption_metadata(attribute, options[:encrypted_copy])
+            result[:encryption_metadata] = [encryption_metadata]
 
-            copy_column = options[:encrypted_copy][:column]
+            encryption_options = self.class.__vault_attributes[attribute].merge({ key: encryption_metadata['key'] })
             copy_ciphertext = self.class.encrypt_value(plaintext, encryption_options)
+            copy_column = options[:encrypted_copy][:column]
 
             write_attribute(copy_column, copy_ciphertext)
             result[copy_column] = copy_ciphertext
@@ -439,6 +452,37 @@ module Vault
             __vault_initialize_attributes!
             clear_changes_information
           end
+        end
+
+        def __vault_get_encryption_metadata(attribute, options)
+          encryption_metadata = {}
+
+          field_path = options[:field_json_path] || "$.#{options[:column]}"
+
+          key = case options[:key]
+                when Symbol
+                  self.send(options[:key])
+                when Proc
+                  self.instance_exec &options[:key]
+                when String
+                  options[:key]
+                end
+
+          { 'field_path' => field_path, 'key' => key }
+        end
+
+        def __vault_merge_encryption_metadata_changes(encryption_metadata_changes)
+          return encryption_metadata_changes unless self.encryption_metadata.present?
+
+          encryption_metadata_changes.each do |change|
+            if existent_record = self.encryption_metadata.find { |record| record['field_path'] == change['field_path'] }
+              existent_record.merge!(change)
+            else
+              self.encryption_metadata << change
+            end
+          end
+
+          self.encryption_metadata
         end
       end
     end

--- a/lib/vault/latest/encrypted_model.rb
+++ b/lib/vault/latest/encrypted_model.rb
@@ -416,7 +416,8 @@ module Vault
             encryption_metadata = __vault_get_encryption_metadata(attribute, options[:encrypted_copy])
             result[:encryption_metadata] = [encryption_metadata]
 
-            encryption_options = self.class.__vault_attributes[attribute].merge({ key: encryption_metadata['key'] })
+            encrypted_copy_options = { key: encryption_metadata['key'], convergent: false }
+            encryption_options = self.class.__vault_attributes[attribute].merge(encrypted_copy_options)
             copy_ciphertext = self.class.encrypt_value(plaintext, encryption_options)
             copy_column = options[:encrypted_copy][:column]
 

--- a/lib/vault/latest/encrypted_model.rb
+++ b/lib/vault/latest/encrypted_model.rb
@@ -373,15 +373,8 @@ module Vault
 
           self.class.__vault_attributes.each do |attribute, options|
             if change = self.__vault_encrypt_attribute!(attribute, options, in_after_save: in_after_save)
-              changes.merge!(change) { |_, old_value, new_value| old_value + new_value }
+              changes.merge!(change)
             end
-          end
-
-          if changes[:encryption_metadata]
-            encryption_metadata_with_changes = __vault_merge_encryption_metadata_changes(changes[:encryption_metadata])
-
-            changes[:encryption_metadata] = encryption_metadata_with_changes
-            write_attribute(:encryption_metadata, encryption_metadata_with_changes)
           end
 
           changes

--- a/lib/vault/latest/encrypted_model.rb
+++ b/lib/vault/latest/encrypted_model.rb
@@ -354,6 +354,12 @@ module Vault
         def __vault_persist_attributes!
           changes = __vault_encrypt_attributes!(in_after_save: true)
 
+          if ActiveRecord.version >= Gem::Version.new('5.1.0')
+            changes[:encryption_metadata] = encryption_metadata if will_save_change_to_attribute?(:encryption_metadata)
+          else
+            changes[:encryption_metadata] = encryption_metadata if attribute_changed?(:encryption_metadata)
+          end
+
           # If there are any changes to the model, update them all at once,
           # skipping any callbacks and validation. This is okay, because we are
           # already in a transaction due to the callback.
@@ -413,10 +419,9 @@ module Vault
           result = { column => ciphertext }
 
           if options[:encrypted_copy]
-            encryption_metadata = __vault_get_encryption_metadata(attribute, options[:encrypted_copy])
-            result[:encryption_metadata] = [encryption_metadata]
+            encryption_metadata = __vault_find_or_create_encryption_metadata_for(options[:encrypted_copy])
 
-            encrypted_copy_options = { key: encryption_metadata['key'], convergent: false }
+            encrypted_copy_options = { key: encryption_metadata['encryption_key_name'], convergent: false }
             encryption_options = self.class.__vault_attributes[attribute].merge(encrypted_copy_options)
             copy_ciphertext = self.class.encrypt_value(plaintext, encryption_options)
             copy_column = options[:encrypted_copy][:column]
@@ -455,10 +460,15 @@ module Vault
           end
         end
 
-        def __vault_get_encryption_metadata(attribute, options)
-          encryption_metadata = {}
-
+        def __vault_find_or_create_encryption_metadata_for(options)
+          encryption_metadata = read_attribute(:encryption_metadata) || []
           field_path = options[:field_json_path] || "$.#{options[:column]}"
+
+          attribute_metadata = encryption_metadata.find do |attribute_metadata|
+            attribute_metadata['field_path'] == field_path
+          end
+
+          return attribute_metadata if attribute_metadata
 
           key = case options[:key]
                 when Symbol
@@ -469,21 +479,11 @@ module Vault
                   options[:key]
                 end
 
-          { 'field_path' => field_path, 'key' => key }
-        end
+          attribute_metadata = { 'field_path' => field_path, 'encryption_key_name' => key }
+          encryption_metadata << attribute_metadata
+          self.encryption_metadata = encryption_metadata
 
-        def __vault_merge_encryption_metadata_changes(encryption_metadata_changes)
-          return encryption_metadata_changes unless self.encryption_metadata.present?
-
-          encryption_metadata_changes.each do |change|
-            if existent_record = self.encryption_metadata.find { |record| record['field_path'] == change['field_path'] }
-              existent_record.merge!(change)
-            else
-              self.encryption_metadata << change
-            end
-          end
-
-          self.encryption_metadata
+          attribute_metadata
         end
       end
     end

--- a/lib/vault/latest/encrypted_model.rb
+++ b/lib/vault/latest/encrypted_model.rb
@@ -463,20 +463,24 @@ module Vault
 
           return attribute_metadata if attribute_metadata
 
-          key = case options[:key]
-                when Symbol
-                  self.send(options[:key])
-                when Proc
-                  self.instance_exec &options[:key]
-                when String
-                  options[:key]
-                end
+          key = get_key_from_encrypted_copy_options(options)
 
           attribute_metadata = { 'field_path' => field_path, 'encryption_key_name' => key }
           encryption_metadata << attribute_metadata
           self.encryption_metadata = encryption_metadata
 
           attribute_metadata
+        end
+
+        def get_key_from_encrypted_copy_options(options)
+          case options[:key]
+          when Symbol
+            self.send(options[:key])
+          when Proc
+            self.instance_exec &options[:key]
+          when String
+            options[:key]
+          end
         end
       end
     end

--- a/lib/vault/legacy/encrypted_model.rb
+++ b/lib/vault/legacy/encrypted_model.rb
@@ -445,20 +445,24 @@ module Vault
 
           return attribute_metadata if attribute_metadata
 
-          key = case options[:key]
-                when Symbol
-                  self.send(options[:key])
-                when Proc
-                  self.instance_exec &options[:key]
-                when String
-                  options[:key]
-                end
+          key = get_key_from_encrypted_copy_options(options)
 
           attribute_metadata = { 'field_path' => field_path, 'encryption_key_name' => key }
           encryption_metadata << attribute_metadata
           self.encryption_metadata = encryption_metadata
 
           attribute_metadata
+        end
+
+        def get_key_from_encrypted_copy_options(options)
+          case options[:key]
+          when Symbol
+            self.send(options[:key])
+          when Proc
+            self.instance_exec &options[:key]
+          when String
+            options[:key]
+          end
         end
       end
     end

--- a/lib/vault/legacy/encrypted_model.rb
+++ b/lib/vault/legacy/encrypted_model.rb
@@ -405,7 +405,8 @@ module Vault
             encryption_metadata = __vault_get_encryption_metadata(attribute, options[:encrypted_copy])
             result[:encryption_metadata] = [encryption_metadata]
 
-            encryption_options = self.class.__vault_attributes[attribute].merge({ key: encryption_metadata['key'] })
+            encrypted_copy_options = { key: encryption_metadata['key'], convergent: false }
+            encryption_options = self.class.__vault_attributes[attribute].merge(encrypted_copy_options)
             copy_ciphertext = self.class.encrypt_value(plaintext, encryption_options)
             copy_column = options[:encrypted_copy][:column]
 

--- a/lib/vault/rails/vault_uniqueness_validator.rb
+++ b/lib/vault/rails/vault_uniqueness_validator.rb
@@ -10,7 +10,7 @@ class VaultUniquenessValidator < ActiveRecord::Validations::UniquenessValidator
 
     encrypted_column = attribute_options[:encrypted_column]
 
-    encrypted_value = record.class.encrypt_value(attribute, value)
+    encrypted_value = record.class.encrypt_attribute(attribute, value)
 
     super(record, encrypted_column, encrypted_value)
 

--- a/spec/dummy/app/models/eager_person.rb
+++ b/spec/dummy/app/models/eager_person.rb
@@ -27,4 +27,16 @@ class EagerPerson < ActiveRecord::Base
   vault_attribute :non_ascii
 
   vault_attribute :email, convergent: true
+
+  vault_attribute :first_name,
+    encrypted_copy: {
+      column: 'first_name_custom_encrypted',
+      key: -> { "241b3098-656f-4120-bb8d-de5e0640f269" }
+    }
+
+  vault_attribute :last_name,
+    encrypted_copy: {
+      column: 'last_name_custom_encrypted',
+      key: -> { "241b3098-656f-4120-bb8d-de5e0640f269" }
+    }
 end

--- a/spec/dummy/app/models/person.rb
+++ b/spec/dummy/app/models/person.rb
@@ -53,4 +53,34 @@ class Person < ActiveRecord::Base
     type: :time,
     encode: -> (raw) { raw.to_s if raw },
     decode: -> (raw) { raw.to_time if raw }
+
+  # Attributes with encrypted copy
+
+  vault_attribute :first_name,
+    encrypted_copy: {
+      column: 'first_name_custom_encrypted',
+      key_column: 'encryption_key'
+    }
+
+  vault_attribute :middle_name,
+    serialize: BinarySerializer,
+    encrypted_copy: {
+      column: 'middle_name_custom_encrypted',
+      key_column: 'encryption_key'
+    }
+
+  vault_attribute :last_name,
+    encrypted_copy: {
+      column: 'last_name_custom_encrypted',
+      key_column: 'encryption_key'
+    },
+    encode: ->(raw) { "xxx#{raw}xxx" },
+    decode: ->(raw) { raw && raw[3...-3] }
+
+  vault_attribute :age,
+    type: :integer,
+    encrypted_copy: {
+      column: 'age_custom_encrypted',
+      key_column: 'encryption_key'
+    }
 end

--- a/spec/dummy/app/models/person.rb
+++ b/spec/dummy/app/models/person.rb
@@ -59,20 +59,20 @@ class Person < ActiveRecord::Base
   vault_attribute :first_name,
     encrypted_copy: {
       column: 'first_name_custom_encrypted',
-      key_column: 'encryption_key'
+      key: -> { "241b3098-656f-4120-bb8d-de5e0640f269" }
     }
 
   vault_attribute :middle_name,
     serialize: BinarySerializer,
     encrypted_copy: {
       column: 'middle_name_custom_encrypted',
-      key_column: 'encryption_key'
+      key: "241b3098-656f-4120-bb8d-de5e0640f269"
     }
 
   vault_attribute :last_name,
     encrypted_copy: {
       column: 'last_name_custom_encrypted',
-      key_column: 'encryption_key'
+      key: -> { "241b3098-656f-4120-bb8d-de5e0640f269" }
     },
     encode: ->(raw) { "xxx#{raw}xxx" },
     decode: ->(raw) { raw && raw[3...-3] }
@@ -81,6 +81,6 @@ class Person < ActiveRecord::Base
     type: :integer,
     encrypted_copy: {
       column: 'age_custom_encrypted',
-      key_column: 'encryption_key'
+      key: -> { "241b3098-656f-4120-bb8d-de5e0640f269" }
     }
 end

--- a/spec/dummy/db/migrate/20200115135409_add_encrypted_copy_columns_to_person.rb
+++ b/spec/dummy/db/migrate/20200115135409_add_encrypted_copy_columns_to_person.rb
@@ -1,6 +1,6 @@
-class AddEncryptedCopyColumnsToPerson < ActiveRecord::Migration[5.2]
+class AddEncryptedCopyColumnsToPerson < ActiveRecord::Migration[5.0]
   def change
-    add_column :people, :encryption_key, :string
+    add_column :people, :encryption_metadata, :text
 
     add_column :people, :first_name_encrypted, :string
     add_column :people, :first_name_custom_encrypted, :string

--- a/spec/dummy/db/migrate/20200115135409_add_encrypted_copy_columns_to_person.rb
+++ b/spec/dummy/db/migrate/20200115135409_add_encrypted_copy_columns_to_person.rb
@@ -1,0 +1,17 @@
+class AddEncryptedCopyColumnsToPerson < ActiveRecord::Migration[5.2]
+  def change
+    add_column :people, :encryption_key, :string
+
+    add_column :people, :first_name_encrypted, :string
+    add_column :people, :first_name_custom_encrypted, :string
+
+    add_column :people, :middle_name_encrypted, :string
+    add_column :people, :middle_name_custom_encrypted, :string
+
+    add_column :people, :last_name_encrypted, :string
+    add_column :people, :last_name_custom_encrypted, :string
+
+    add_column :people, :age_encrypted, :string
+    add_column :people, :age_custom_encrypted, :string
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,31 +10,40 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181212095513) do
+ActiveRecord::Schema.define(version: 2020_01_15_135409) do
 
   create_table "people", force: :cascade do |t|
-    t.string   "name"
-    t.string   "ssn_encrypted"
-    t.string   "cc_encrypted"
-    t.string   "details_encrypted"
-    t.string   "business_card_encrypted"
-    t.string   "favorite_color_encrypted"
-    t.string   "non_ascii_encrypted"
-    t.datetime "created_at",                       null: false
-    t.datetime "updated_at",                       null: false
-    t.string   "email_encrypted"
-    t.string   "integer_data_encrypted"
-    t.string   "float_data_encrypted"
-    t.string   "time_data_encrypted"
-    t.string   "county"
-    t.string   "county_encrypted"
-    t.string   "state"
-    t.string   "state_encrypted"
-    t.string   "date_of_birth"
-    t.string   "date_of_birth_encrypted"
-    t.string   "passport_number_encrypted"
-    t.string   "driving_licence_number_encrypted"
-    t.string   "ip_address_encrypted"
+    t.string "name"
+    t.string "ssn_encrypted"
+    t.string "cc_encrypted"
+    t.string "details_encrypted"
+    t.string "business_card_encrypted"
+    t.string "favorite_color_encrypted"
+    t.string "non_ascii_encrypted"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "email_encrypted"
+    t.string "integer_data_encrypted"
+    t.string "float_data_encrypted"
+    t.string "time_data_encrypted"
+    t.string "county"
+    t.string "county_encrypted"
+    t.string "state"
+    t.string "state_encrypted"
+    t.string "date_of_birth"
+    t.string "date_of_birth_encrypted"
+    t.string "passport_number_encrypted"
+    t.string "driving_licence_number_encrypted"
+    t.string "ip_address_encrypted"
+    t.string "encryption_key"
+    t.string "first_name_encrypted"
+    t.string "first_name_custom_encrypted"
+    t.string "middle_name_encrypted"
+    t.string "middle_name_custom_encrypted"
+    t.string "last_name_encrypted"
+    t.string "last_name_custom_encrypted"
+    t.string "age_encrypted"
+    t.string "age_custom_encrypted"
   end
 
 end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,40 +10,40 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_15_135409) do
+ActiveRecord::Schema.define(version: 20200115135409) do
 
   create_table "people", force: :cascade do |t|
-    t.string "name"
-    t.string "ssn_encrypted"
-    t.string "cc_encrypted"
-    t.string "details_encrypted"
-    t.string "business_card_encrypted"
-    t.string "favorite_color_encrypted"
-    t.string "non_ascii_encrypted"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.string "email_encrypted"
-    t.string "integer_data_encrypted"
-    t.string "float_data_encrypted"
-    t.string "time_data_encrypted"
-    t.string "county"
-    t.string "county_encrypted"
-    t.string "state"
-    t.string "state_encrypted"
-    t.string "date_of_birth"
-    t.string "date_of_birth_encrypted"
-    t.string "passport_number_encrypted"
-    t.string "driving_licence_number_encrypted"
-    t.string "ip_address_encrypted"
-    t.string "encryption_key"
-    t.string "first_name_encrypted"
-    t.string "first_name_custom_encrypted"
-    t.string "middle_name_encrypted"
-    t.string "middle_name_custom_encrypted"
-    t.string "last_name_encrypted"
-    t.string "last_name_custom_encrypted"
-    t.string "age_encrypted"
-    t.string "age_custom_encrypted"
+    t.string   "name"
+    t.string   "ssn_encrypted"
+    t.string   "cc_encrypted"
+    t.string   "details_encrypted"
+    t.string   "business_card_encrypted"
+    t.string   "favorite_color_encrypted"
+    t.string   "non_ascii_encrypted"
+    t.datetime "created_at",                       null: false
+    t.datetime "updated_at",                       null: false
+    t.string   "email_encrypted"
+    t.string   "integer_data_encrypted"
+    t.string   "float_data_encrypted"
+    t.string   "time_data_encrypted"
+    t.string   "county"
+    t.string   "county_encrypted"
+    t.string   "state"
+    t.string   "state_encrypted"
+    t.string   "date_of_birth"
+    t.string   "date_of_birth_encrypted"
+    t.string   "passport_number_encrypted"
+    t.string   "driving_licence_number_encrypted"
+    t.string   "ip_address_encrypted"
+    t.text     "encryption_metadata"
+    t.string   "first_name_encrypted"
+    t.string   "first_name_custom_encrypted"
+    t.string   "middle_name_encrypted"
+    t.string   "middle_name_custom_encrypted"
+    t.string   "last_name_encrypted"
+    t.string   "last_name_custom_encrypted"
+    t.string   "age_encrypted"
+    t.string   "age_custom_encrypted"
   end
 
 end


### PR DESCRIPTION
This PR updates `vault_attribute` method to support `:encrypted_copy` option. 
If the option is supplied the given attribute will be encrypted twice by using the given key (key can also be a function name, or lambda).

The encrypted copy will not be used when decrypting a value. 
The encrypted copy is just a copy of the original data encrypted with a different key, meant to be used by someone else.

Example: 
```
vault_attribute :first_name,
  encrypted_copy: { 
    column: 'first_name_custom_encrypted',
    key: -> { uuid } 
  }
```
That will cause `first_name` to be encrypted twice:
• into `first_name_encrypted` using `#{application_name}_#{table_name}_first_name` as a key
• into `first_name_custom_encrypted` using the `uuid` field of the record

TODO:
- [ ] Develop support for encrypting values inside of a JSON column
- [ ] Think about if we can set `encryption_metadata` only on record creation
