### PR TITLE
TypeError no implicit conversion into String fix

### DIFF
--- a/lib/vault/rails.rb
+++ b/lib/vault/rails.rb
@@ -208,7 +208,7 @@ module Vault
                cipher.random_iv
              end
 
-        Base64.strict_encode64(iv + cipher.update(plaintext) + cipher.final)
+        Base64.strict_encode64(iv + cipher.update(plaintext.to_s) + cipher.final)
       end
 
       # Perform in-memory encryption. This is useful for testing and development.


### PR DESCRIPTION
An important amount of the failing spec files in FCA in the new migrations are because a `TypeError: no implicit conversion of _ into String`, this change prevent this error to raise. 