### PR TITLE
Fix deprecation warning when using connection_config

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -90,6 +90,20 @@ steps:
       - build_rails51
       - build_rails52
 
+  - name: build_rails7
+    image: ruby:3.0-alpine
+    environment:
+      BUNDLE_GEMFILE: gemfiles/rails_7.gemfile
+      DISABLE_DATABASE_ENVIRONMENT_CHECK: 1
+      <<: [*vault_tag, *artifactory_credentials]
+    commands: *commands
+    depends_on:
+      - build_rails4
+      - build_rails5
+      - build_rails51
+      - build_rails52
+      - build_rails6
+
   - name: publish_feature_branch_gem
     image: quay.io/fundingcircle/alpine-ruby-builder:2.7
     environment:
@@ -111,6 +125,7 @@ steps:
       - build_rails51
       - build_rails52
       - build_rails6
+      - build_rails7
     when:
       branch:
         exclude:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Vault Rails Changelog
 
-## 2.1.2 (September 8, 2023)
+## 2.1.2 (November 17, 2023)
 
 IMPROVEMENTS
 - Add Rails 7 Support
+- Fix "DEPRECATION WARNING: connection_config is deprecated and will be removed from Rails 7.0"
 
 ## 2.1.1 (January 31, 2022)
 

--- a/lib/vault/latest/encrypted_model.rb
+++ b/lib/vault/latest/encrypted_model.rb
@@ -167,10 +167,12 @@ module Vault
           attribute_type = options.fetch(:type, ActiveRecord::Type::Value.new)
 
           if attribute_type.is_a?(Symbol)
-            if ActiveRecord::Base.connection_config[:adapter]
-              ActiveRecord::Type.lookup(attribute_type, adapter: ActiveRecord::Base.connection_config[:adapter])
+            adapter = ActiveRecord::Base.try(:connection_db_config).try(:adapter) || (ActiveRecord::Base.try(:connection_config) || {})[:adapter]
+
+            if adapter
+              ActiveRecord::Type.lookup(attribute_type, adapter: adapter)
             else
-              ActiveRecord::Type.lookup(attribute_type) # This call does a db connection, best find a way to configure `ActiveRecord::Base.connection_config[:adapter]`
+              ActiveRecord::Type.lookup(attribute_type) # This call does a db connection, best find a way to configure the adapter
             end
           else
             ActiveModel::Type::Value.new

--- a/lib/vault/rails/version.rb
+++ b/lib/vault/rails/version.rb
@@ -1,6 +1,6 @@
 module Vault
   module Rails
-    VERSION = "2.1.1"
+    VERSION = '2.1.2'
 
     def self.latest?
       ActiveRecord.version >= Gem::Version.new('5.0.0')


### PR DESCRIPTION
```
ActiveRecord::Base.try(:connection_db_config).try(:adapter)
=> "postgresql"

ActiveRecord::Base.try(:connection_config)[:adapter]
W, [2023-11-17T16:12:59.253878+02:00 #22587] DEPRECATION WARNING: connection_config is deprecated and will be removed from Rails 7.0 (Use connection_db_config instead) (called from <main> at (pry):6)
=> "postgresql"
```