### PR TITLE
Version 2.1.2 add rails 7.0 support

### DIFF
--- a/lib/vault/rails/version.rb
+++ b/lib/vault/rails/version.rb
@@ -1,6 +1,6 @@
 module Vault
   module Rails
-    VERSION = "2.1.1"
+    VERSION = "2.1.2"
 
     def self.latest?
       ActiveRecord.version >= Gem::Version.new('5.0.0')


### PR DESCRIPTION
Fix the gem version 2.1.2, same as the changelog

## 2.1.2 (September 8, 2023)

IMPROVEMENTS
- Add Rails 7 Support

https://github.com/FundingCircle/fc-vault-rails/pull/91